### PR TITLE
Account menu, password management, auth hardening & attendance polish

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,0 +1,127 @@
+import {
+  Flex,
+  Text,
+  Box,
+  Avatar,
+  Badge,
+  Icon,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
+  MenuDivider,
+  useDisclosure,
+} from "@chakra-ui/react";
+import { FaChevronDown, FaArrowLeft, FaKey, FaSignOutAlt } from "react-icons/fa";
+import { useNavigate } from "react-router-dom";
+import { PROTECTED_PATHS } from "routes/pagePath";
+import useGlobalStore, { EMPTY_USER, EMPTY_ORG } from "zStore";
+import ChangePasswordModal from "components/auth/ChangePasswordModal";
+
+interface AppHeaderProps {
+  /** When inside an organisation (e.g. the Dashboard), surfaces the role badge
+   *  and a quick link back to the organisations list. */
+  inOrg?: boolean;
+}
+
+const AppHeader = ({ inOrg = false }: AppHeaderProps) => {
+  const navigate = useNavigate();
+  const changePassword = useDisclosure();
+  const [user, organisation, setUser, updateOrganisation] = useGlobalStore((s) => [
+    s.user,
+    s.organisation,
+    s.setUser,
+    s.updateOrganisation,
+  ]);
+
+  const handleLogout = () => {
+    setUser(EMPTY_USER);
+    updateOrganisation(EMPTY_ORG);
+  };
+
+  const displayName = user.username || "Account";
+
+  return (
+    <Flex bg="blue.500" justifyContent="space-between" alignItems="center" p="4">
+      <Text fontWeight="bold" color="#fff">
+        Attendance Tracker
+      </Text>
+
+      <Menu placement="bottom-end" autoSelect={false}>
+        <MenuButton
+          px={2}
+          py={1}
+          borderRadius="md"
+          transition="background 0.2s"
+          _hover={{ bg: "blue.600" }}
+          _active={{ bg: "blue.600" }}
+          aria-label="Account menu"
+        >
+          <Flex alignItems="center" gap={2}>
+            <Avatar size="sm" name={user.username} />
+            <Text
+              color="#fff"
+              fontWeight="medium"
+              maxW="160px"
+              noOfLines={1}
+              display={{ base: "none", md: "block" }}
+            >
+              {displayName}
+            </Text>
+            <Icon
+              as={FaChevronDown}
+              color="#fff"
+              boxSize={3}
+              display={{ base: "none", md: "block" }}
+            />
+          </Flex>
+        </MenuButton>
+
+        <MenuList>
+          <Box px={3} py={2}>
+            <Text fontWeight="bold" noOfLines={1}>
+              {displayName}
+            </Text>
+            {user.email && (
+              <Text fontSize="sm" color="gray.500" noOfLines={1}>
+                {user.email}
+              </Text>
+            )}
+            {inOrg && organisation.roleName && (
+              <Badge mt={2} colorScheme="blue">
+                {organisation.roleName}
+              </Badge>
+            )}
+          </Box>
+
+          <MenuDivider />
+
+          {inOrg && (
+            <MenuItem
+              icon={<FaArrowLeft />}
+              onClick={() => navigate(PROTECTED_PATHS.ALL_ORG)}
+            >
+              Organisations
+            </MenuItem>
+          )}
+          <MenuItem icon={<FaKey />} onClick={changePassword.onOpen}>
+            Change password
+          </MenuItem>
+
+          <MenuDivider />
+
+          <MenuItem icon={<FaSignOutAlt />} color="red.500" onClick={handleLogout}>
+            Logout
+          </MenuItem>
+        </MenuList>
+      </Menu>
+
+      <ChangePasswordModal
+        isOpen={changePassword.isOpen}
+        onClose={changePassword.onClose}
+      />
+    </Flex>
+  );
+};
+
+export default AppHeader;

--- a/src/components/auth/ChangePasswordModal.tsx
+++ b/src/components/auth/ChangePasswordModal.tsx
@@ -1,0 +1,145 @@
+import {
+  Modal, ModalOverlay, ModalContent, ModalHeader, ModalCloseButton,
+  ModalBody, ModalFooter, FormControl, FormLabel, FormErrorMessage,
+  Button, Stack,
+} from "@chakra-ui/react";
+import { useForm, SubmitHandler } from "react-hook-form";
+import { toast } from "react-toastify";
+import PasswordInput from "components/PasswordInput";
+import { authRequest } from "services";
+import { patchRequest, useMutationWrapper } from "services/api/apiHelper";
+import useGlobalStore, { EMPTY_USER } from "zStore";
+
+interface ChangePasswordModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+interface ChangePasswordInputs {
+  currentPassword: string;
+  newPassword: string;
+  confirmPassword: string;
+}
+
+const PASSWORD_MIN_LENGTH = 6;
+
+const ChangePasswordModal = ({ isOpen, onClose }: ChangePasswordModalProps) => {
+  const setUser = useGlobalStore((s) => s.setUser);
+  const {
+    register, handleSubmit, watch, reset, setError, formState: { errors },
+  } = useForm<ChangePasswordInputs>();
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const onSuccess = () => {
+    toast.success("Password updated");
+    handleClose();
+  };
+
+  const onError = (error: { response?: { status?: number; data?: { error?: string } } }) => {
+    const status = error?.response?.status;
+    const message = error?.response?.data?.error;
+
+    if (status === 401) {
+      // Two kinds of 401 share this status: a wrong current password (a form
+      // error the user can fix) vs. a dead/expired session. Key off the message
+      // to tell them apart — only the session case should drop the user to login.
+      if (/current password/i.test(message ?? "")) {
+        setError("currentPassword", {
+          type: "server",
+          message: "Current password is incorrect",
+        });
+        return;
+      }
+      toast.error(message ?? "Your session has expired. Please sign in again.");
+      setUser(EMPTY_USER);
+      return;
+    }
+
+    if (status === 429) {
+      toast.error("Too many attempts, please try again later.");
+      return;
+    }
+
+    // 422 (validation) and anything else — surface the server's message.
+    toast.error(message ?? "Something went wrong. Please try again.");
+  };
+
+  const { mutate, isLoading } = useMutationWrapper(patchRequest, onSuccess, onError);
+
+  const onSubmit: SubmitHandler<ChangePasswordInputs> = ({ currentPassword, newPassword }) =>
+    mutate({
+      url: authRequest.UPDATE_PASSWORD,
+      data: { currentPassword, newPassword },
+    });
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Change password</ModalHeader>
+        <ModalCloseButton />
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <ModalBody>
+            <Stack spacing={4}>
+              <FormControl isInvalid={!!errors.currentPassword}>
+                <FormLabel>Current password</FormLabel>
+                <PasswordInput
+                  autoComplete="current-password"
+                  {...register("currentPassword", {
+                    required: "Current password is required",
+                  })}
+                />
+                <FormErrorMessage>{errors.currentPassword?.message}</FormErrorMessage>
+              </FormControl>
+
+              <FormControl isInvalid={!!errors.newPassword}>
+                <FormLabel>New password</FormLabel>
+                <PasswordInput
+                  autoComplete="new-password"
+                  {...register("newPassword", {
+                    required: "New password is required",
+                    minLength: {
+                      value: PASSWORD_MIN_LENGTH,
+                      message: `Password must be at least ${PASSWORD_MIN_LENGTH} characters`,
+                    },
+                    validate: (value) =>
+                      value !== watch("currentPassword") ||
+                      "New password must be different from your current password",
+                  })}
+                />
+                <FormErrorMessage>{errors.newPassword?.message}</FormErrorMessage>
+              </FormControl>
+
+              <FormControl isInvalid={!!errors.confirmPassword}>
+                <FormLabel>Confirm new password</FormLabel>
+                <PasswordInput
+                  autoComplete="new-password"
+                  {...register("confirmPassword", {
+                    required: "Please confirm your new password",
+                    validate: (value) =>
+                      value === watch("newPassword") || "Passwords do not match",
+                  })}
+                />
+                <FormErrorMessage>{errors.confirmPassword?.message}</FormErrorMessage>
+              </FormControl>
+            </Stack>
+          </ModalBody>
+          <ModalFooter>
+            <Button variant="ghost" mr={3} onClick={handleClose} isDisabled={isLoading}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" isLoading={isLoading}>
+              Update password
+            </Button>
+          </ModalFooter>
+        </form>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default ChangePasswordModal;

--- a/src/helpers/stringManipulations.ts
+++ b/src/helpers/stringManipulations.ts
@@ -9,6 +9,12 @@ export function capitalize(text = ''): string {
   return text.slice(0, 1).toUpperCase() + text.slice(1).toLowerCase()
 }
 
+/** Upper-cases the first letter only, leaving the rest untouched (preserves acronyms). */
+export function capitalizeFirstLetter(text = ''): string {
+  if (!text || typeof text !== 'string') return ''
+  return text.slice(0, 1).toUpperCase() + text.slice(1)
+}
+
 export function capitalizeEachWordInSentence(
   text: string,
   seperator = ' '

--- a/src/pages/AllAttendance.tsx
+++ b/src/pages/AllAttendance.tsx
@@ -5,6 +5,7 @@ import {
   Text,
   Stack,
   Button,
+  Badge,
 } from "@chakra-ui/react";
 import { useNavigate } from "react-router-dom";
 import { PROTECTED_PATHS } from "routes/pagePath";
@@ -12,21 +13,27 @@ import { useQueryWrapper } from "services/api/apiHelper";
 import { useState } from "react";
 import { attendanceRequest } from "services";
 import useGlobalStore from "zStore";
-import { convertParamsToString } from "helpers/stringManipulations";
+import {
+  capitalizeFirstLetter,
+  convertParamsToString,
+} from "helpers/stringManipulations";
 import { FaArrowCircleLeft, FaPencilAlt } from "react-icons/fa";
 import { format } from "date-fns";
 import LoadingSpinner from "components/LoadingSpinner";
 
+type PersonRef = { id: string; name: string };
+
 type AttendanceType = {
   name: string;
-  image: string;
-  owner: string;
   createdAt: string;
   updatedAt: string;
   id: string;
   hasBeenUpdated: boolean;
   date: string;
   dateFormated: number;
+  category?: { name: string; status: string } | null;
+  createdBy?: PersonRef | null;
+  updatedBy?: PersonRef | null;
 };
 
 const AllAttendance = () => {
@@ -112,12 +119,26 @@ const AllAttendance = () => {
                     w="100%"
                   >
                     <Box>
-                      <Text textAlign="left">{attendance.name}</Text>
-                      <Text>
-                        {format(new Date(attendance.date), "EEE dd MMM yy")}
-                      </Text>
-                      <Text fontSize="xs" color="gray.500">
-                        Created: {format(new Date(attendance.createdAt), "EEE dd MMM yy, hh:mm a")}
+                      <Flex alignItems="center" gap={2}>
+                        <Text textAlign="left" fontWeight="semibold">
+                          {capitalizeFirstLetter(attendance.name)}
+                        </Text>
+                        {attendance.hasBeenUpdated && (
+                          <Badge colorScheme="orange" fontSize="0.65rem">
+                            Edited
+                          </Badge>
+                        )}
+                      </Flex>
+                      {attendance.category?.name && (
+                        <Badge colorScheme="purple" mt={1}>
+                          {attendance.category.name}
+                        </Badge>
+                      )}
+                      <Text fontSize="xs" color="gray.500" mt={1}>
+                        {attendance.createdBy?.name &&
+                          `by ${attendance.createdBy.name}, `}
+                        {format(new Date(attendance.date), "EEE dd MMM yy")},{" "}
+                        {format(new Date(attendance.createdAt), "hh:mm a")}
                       </Text>
                     </Box>
                     <Flex>
@@ -130,7 +151,7 @@ const AllAttendance = () => {
                             e.stopPropagation();
                             const pagePath = convertParamsToString(
                               PROTECTED_PATHS.UPDATE_ATTENANCE,
-                              { attendanceId: attendance.id }
+                              { attendanceId: attendance.id },
                             );
                             navigate(pagePath);
                           }}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,12 +1,9 @@
 import {
   Box,
-  Flex,
   useColorModeValue,
-  Text,
   Button,
   Heading,
   Grid,
-  HStack,
 } from "@chakra-ui/react";
 import {
   FaUserPlus,
@@ -15,14 +12,14 @@ import {
   FaEye,
   FaChartBar,
   FaBirthdayCake,
-  FaArrowLeft,
   FaMoneyBillWave,
   FaUserShield,
 } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 import { PROTECTED_PATHS } from "routes/pagePath";
 import { IconType } from "react-icons";
-import useGlobalStore, { EMPTY_USER, EMPTY_ORG } from "zStore";
+import useGlobalStore from "zStore";
+import AppHeader from "components/AppHeader";
 import { Can } from "rbac/Can";
 import { PermissionKey } from "rbac/permissions";
 import { useSyncSelectedOrg } from "rbac/useSyncSelectedOrg";
@@ -48,42 +45,12 @@ const DASHBOARD_ACTIONS: DashboardAction[] = [
 
 const Dashboard = () => {
   const navigate = useNavigate();
-  const [organisation, setUser, updateOrganisation] = useGlobalStore((state) => [
-    state.organisation,
-    state.setUser,
-    state.updateOrganisation,
-  ]);
+  const organisation = useGlobalStore((state) => state.organisation);
   useSyncSelectedOrg();
-
-  function handleLogout() {
-    setUser(EMPTY_USER);
-    updateOrganisation(EMPTY_ORG);
-  }
 
   return (
     <Box minH={"100vh"} bg={useColorModeValue("gray.50", "gray.800")}>
-      <Flex
-        bg="blue.500"
-        justifyContent="space-between"
-        alignItems="center"
-        p="4"
-      >
-        <Text fontWeight="bold" color="#fff">
-          Attendance Tracker
-        </Text>
-        <HStack spacing={3}>
-          <Button
-            variant="logout"
-            leftIcon={<FaArrowLeft />}
-            onClick={() => navigate(PROTECTED_PATHS.ALL_ORG)}
-          >
-            Organisations
-          </Button>
-          <Button variant="logout" onClick={handleLogout}>
-            Logout
-          </Button>
-        </HStack>
-      </Flex>
+      <AppHeader inOrg />
 
       <Heading mt="4" fontSize="22px" textAlign="center">
         {organisation?.name || "Dashboard"}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -11,10 +11,10 @@ import {
   Heading,
   Text,
   useColorModeValue,
-  useBoolean,
 } from "@chakra-ui/react";
 import { useState } from "react";
 import { Link as RouterLink } from "react-router-dom";
+import PasswordInput from "components/PasswordInput";
 import { authRequest } from "services";
 import { postRequest, useMutationWrapper } from "services/api/apiHelper";
 import { PUBLIC_PATHS } from "routes/pagePath";
@@ -39,7 +39,6 @@ const Login = () => {
       },
     });
   };
-  const [showPassword, setShowPassword] = useBoolean(true);
   return (
     <Flex
       minH={"100vh"}
@@ -72,19 +71,10 @@ const Login = () => {
               </FormControl>
               <FormControl id="password">
                 <FormLabel>Password</FormLabel>
-                <Flex>
-                  <Input
-                    type={showPassword ? "password" : "text"}
-                    onChange={(e) => setPassword(e.target.value)}
-                    autoComplete="current-password"
-                  />
-                  <Button
-                    variant="secondary"
-                    onClick={() => setShowPassword.toggle()}
-                  >
-                    {showPassword ? "Show" : "hide"}
-                  </Button>
-                </Flex>
+                <PasswordInput
+                  onChange={(e) => setPassword(e.target.value)}
+                  autoComplete="current-password"
+                />
               </FormControl>
               <Stack spacing={10}>
                 <Stack

--- a/src/pages/MarkAttendance.tsx
+++ b/src/pages/MarkAttendance.tsx
@@ -8,10 +8,15 @@ import {
   Heading,
   InputGroup,
   InputLeftElement,
+  InputRightElement,
+  IconButton,
+  Icon,
   Container,
 } from "@chakra-ui/react";
+import { FaSearch } from "react-icons/fa";
+import { FiX } from "react-icons/fi";
 import { convertParamsToString } from "helpers/stringManipulations";
-import { useCallback, useRef, useState } from "react";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { PROTECTED_PATHS } from "routes/pagePath";
 import { attendanceRequest, orgRequest } from "services";
@@ -28,8 +33,10 @@ import _ from "lodash";
 import { toast } from "react-toastify";
 import LoadingSpinner from "components/LoadingSpinner";
 
+export type AttendanceStatus = "absent" | "present" | "apology";
+
 export type MemberType = {
-  attendanceStatus: "absent" | "present" | "apology";
+  attendanceStatus: AttendanceStatus;
   name: string;
   id: string;
 };
@@ -40,74 +47,94 @@ type AttendanceInfoType = {
   absent: number;
 };
 
+// Tapping a member cycles their status in this order.
+const NEXT_STATUS: Record<AttendanceStatus, AttendanceStatus> = {
+  absent: "present",
+  present: "apology",
+  apology: "absent",
+};
+
+/** Tally statuses in a single pass — this runs on every toggle. */
+const computeCounts = (members: MemberType[]): AttendanceInfoType =>
+  members.reduce(
+    (acc, member) => {
+      acc[member.attendanceStatus] += 1;
+      return acc;
+    },
+    { present: 0, apology: 0, absent: 0 }
+  );
+
+// One member button. Memoized so toggling a single member only re-renders that
+// row, not the whole (potentially large) roster.
+const MemberRow = memo(
+  ({
+    member,
+    onToggle,
+  }: {
+    member: MemberType;
+    onToggle: (id: string) => void;
+  }) => (
+    <Button
+      variant="unstyled"
+      onClick={() => onToggle(member.id)}
+      display="block"
+      w="full"
+      mt="3"
+      border="1px solid green"
+      bg={
+        member.attendanceStatus === "present"
+          ? "green"
+          : member.attendanceStatus === "apology"
+          ? "orange"
+          : ""
+      }
+      color={member.attendanceStatus === "absent" ? "" : "#fff"}
+    >
+      {member.name}
+    </Button>
+  )
+);
+MemberRow.displayName = "MemberRow";
+
 const MarkAttendance = () => {
   const [allMembers, setAllMembers] = useState<MemberType[]>([]);
-  const [filterName, setFilterName] = useState<MemberType[]>([]);
+  const [searchQuery, setSearchQuery] = useState("");
   const [org, currentAttendance, setAttendance] = useGlobalStore((state) => [
     state.organisation,
     state.currentAttendance,
     state.updateCurrentAttendance,
   ]);
-  const [attendanceInfo, setAttendanceInfo] = useState<AttendanceInfoType>({
-    present: 0,
-    apology: 0,
-    absent: 0,
-  });
   const params = useParams();
   const isUpdate = params.attendanceId !== undefined;
   const localStorageKey = `attendance-${org.id}`;
 
+  // filtered list + status counts are pure derivations of allMembers/searchQuery,
+  // so we compute them here instead of storing (and hand-syncing) extra state.
+  const filteredMembers = useMemo(() => {
+    const query = searchQuery.toLowerCase();
+    return allMembers.filter((member) =>
+      member.name.toLowerCase().includes(query)
+    );
+  }, [allMembers, searchQuery]);
+  const attendanceInfo = useMemo(() => computeCounts(allMembers), [allMembers]);
+
   // Callback for fetching all members (new attendance marking)
   const onGetMembersSuccess = (data) => {
-    console.log("data:", data);
-    const unsorted = data.data;
-    const members = unsorted.sort((a, b) => a.name.localeCompare(b.name));
-    // Default every member to "absent"
-    const membersWithAttendStatus = members.map((member) => ({
-      ...member,
-      attendanceStatus: "absent",
-    }));
+    const members = [...data.data].sort((a, b) => a.name.localeCompare(b.name));
 
+    // Resume from a locally-saved draft if one exists, otherwise start everyone
+    // off as "absent".
     const localAttendance = localStorage.getItem(localStorageKey);
     if (localAttendance) {
       const parsedLocal = JSON.parse(localAttendance);
       if (parsedLocal.length > 0) {
         setAllMembers(parsedLocal);
-        setFilterName(parsedLocal);
-        const presentCount = parsedLocal.filter(
-          (member) => member.attendanceStatus === "present"
-        ).length;
-        const apologyCount = parsedLocal.filter(
-          (member) => member.attendanceStatus === "apology"
-        ).length;
-        const absentCount = parsedLocal.filter(
-          (member) => member.attendanceStatus === "absent"
-        ).length;
-        setAttendanceInfo({
-          present: presentCount,
-          apology: apologyCount,
-          absent: absentCount,
-        });
-      } else {
-        // If localStorage exists but is empty, use fetched data.
-        setAllMembers(membersWithAttendStatus);
-        setFilterName(membersWithAttendStatus);
-        setAttendanceInfo({
-          present: 0,
-          apology: 0,
-          absent: membersWithAttendStatus.length,
-        });
+        return;
       }
-    } else {
-      // For a new attendance marking, all members default to absent
-      setAllMembers(membersWithAttendStatus);
-      setFilterName(membersWithAttendStatus);
-      setAttendanceInfo({
-        present: 0,
-        apology: 0,
-        absent: membersWithAttendStatus.length,
-      });
     }
+    setAllMembers(
+      members.map((member) => ({ ...member, attendanceStatus: "absent" }))
+    );
   };
 
   // Query to fetch members (only when not updating)
@@ -140,24 +167,8 @@ const MarkAttendance = () => {
         name: attend.member.name,
         attendanceStatus: attend.attendanceStatus, // expects "present", "apology" or "absent"
       }));
-    // Store in localStorage and update state
     localStorage.setItem(localStorageKey, JSON.stringify(updatedMembers));
     setAllMembers(updatedMembers);
-    setFilterName(updatedMembers);
-    const presentCount = updatedMembers.filter(
-      (m) => m.attendanceStatus === "present"
-    ).length;
-    const apologyCount = updatedMembers.filter(
-      (m) => m.attendanceStatus === "apology"
-    ).length;
-    const absentCount = updatedMembers.filter(
-      (m) => m.attendanceStatus === "absent"
-    ).length;
-    setAttendanceInfo({
-      present: presentCount,
-      apology: apologyCount,
-      absent: absentCount,
-    });
   };
 
   const attendUrl = convertParamsToString(attendanceRequest.GET_ATTENDANCE, {
@@ -176,57 +187,26 @@ const MarkAttendance = () => {
 
   const isLoadingData = isUpdate ? isGettingAttendance : isGettingMembers;
 
-  const [searchQuery, setSearchQuery] = useState("");
-  const handleSearch = useCallback(
-    (e) => {
-      const query = e.target.value.toLowerCase();
-      setSearchQuery(query);
-      setFilterName(
-        allMembers.filter((member) => member.name.toLowerCase().includes(query))
-      );
-    },
-    [allMembers]
-  );
+  const handleSearch = useCallback((e) => {
+    setSearchQuery(e.target.value);
+  }, []);
 
-  // Toggle a member's attendance status by cycling through: absent -> present -> apology -> absent
+  // Cycle a member's status: absent -> present -> apology -> absent
   const updateAttendance = useCallback(
     (userId) => {
       setAllMembers((prevMembers) => {
         const updatedMembers = prevMembers.map((member) => {
           if (member.id !== userId) return member;
-          let newStatus = member.attendanceStatus;
-          if (!newStatus || newStatus === "absent") {
-            newStatus = "present";
-          } else if (newStatus === "present") {
-            newStatus = "apology";
-          } else if (newStatus === "apology") {
-            newStatus = "absent";
-          }
-          return { ...member, attendanceStatus: newStatus };
+          return {
+            ...member,
+            attendanceStatus: NEXT_STATUS[member.attendanceStatus] ?? "present",
+          };
         });
-        const presentCount = updatedMembers.filter(
-          (m) => m.attendanceStatus === "present"
-        ).length;
-        const apologyCount = updatedMembers.filter(
-          (m) => m.attendanceStatus === "apology"
-        ).length;
-        const absentCount = updatedMembers.filter(
-          (m) => m.attendanceStatus === "absent"
-        ).length;
-        setAttendanceInfo({
-          present: presentCount,
-          apology: apologyCount,
-          absent: absentCount,
-        });
-        const filteredMembers = updatedMembers.filter((member) =>
-          member.name.toLowerCase().includes(searchQuery)
-        );
-        setFilterName(filteredMembers);
         localStorage.setItem(localStorageKey, JSON.stringify(updatedMembers));
         return updatedMembers;
       });
     },
-    [localStorageKey, searchQuery]
+    [localStorageKey]
   );
 
   const navigate = useNavigate();
@@ -243,26 +223,10 @@ const MarkAttendance = () => {
   const { mutate, isLoading } = useMutationWrapper(
     isUpdate ? putRequest : postRequest,
     onSubmitSuccess,
-    () => { isSubmittingRef.current = false; }
+    () => {
+      isSubmittingRef.current = false;
+    }
   );
-
-  const onSubmit = () => {
-    confirmAlert({
-      title: "Please verify count",
-      message: `Are you sure you want to submit?`,
-      buttons: [
-        {
-          label: "Yes",
-          className: "confirm-alert-button confirm-alert-button-yes",
-          onClick: () => sendAttandanceToAPI(),
-        },
-        {
-          label: "No",
-          className: "confirm-alert-button confirm-alert-button-no",
-        },
-      ],
-    });
-  };
 
   const sendAttandanceToAPI = useCallback(() => {
     if (isSubmittingRef.current) return;
@@ -282,24 +246,32 @@ const MarkAttendance = () => {
     if (apologisedMembers.length) {
       data.apologisedMembers = apologisedMembers;
     }
-    const upateUrl = convertParamsToString(
-      attendanceRequest.UPDATE_ATTENDANCE,
-      {
-        attendanceId: params.attendanceId as string,
-      }
-    );
+    const upateUrl = convertParamsToString(attendanceRequest.UPDATE_ATTENDANCE, {
+      attendanceId: params.attendanceId as string,
+    });
     mutate({
       url: isUpdate ? upateUrl : attendanceRequest.ATTENDANCE,
       data,
     });
-  }, [
-    allMembers,
-    currentAttendance,
-    org.id,
-    params.attendanceId,
-    mutate,
-    isUpdate,
-  ]);
+  }, [allMembers, currentAttendance, org.id, params.attendanceId, mutate, isUpdate]);
+
+  const onSubmit = () => {
+    confirmAlert({
+      title: "Please verify count",
+      message: `Are you sure you want to submit?`,
+      buttons: [
+        {
+          label: "Yes",
+          className: "confirm-alert-button confirm-alert-button-yes",
+          onClick: () => sendAttandanceToAPI(),
+        },
+        {
+          label: "No",
+          className: "confirm-alert-button confirm-alert-button-no",
+        },
+      ],
+    });
+  };
 
   return (
     <Box minH={"100vh"} bg={useColorModeValue("gray.50", "gray.800")}>
@@ -314,15 +286,14 @@ const MarkAttendance = () => {
         </Text>
       </Flex>
       <Container>
-        <Flex alignItems="center" justifyContent="space-between">
-          <Heading mt="4" fontSize="22px">
-            {` Members ${currentAttendance.name}`}
+        <Flex alignItems="center" justifyContent="space-between" mt="4">
+          <Heading fontSize="22px">
+            {`Members ${currentAttendance.name}`}
           </Heading>
           <Button
             variant="logout"
             onClick={() => {
               localStorage.removeItem(localStorageKey);
-
               window.location.reload();
             }}
           >
@@ -334,14 +305,28 @@ const MarkAttendance = () => {
         ) : (
           <>
             <InputGroup mt="4">
-              <InputLeftElement pointerEvents="none" />
+              <InputLeftElement pointerEvents="none">
+                <Icon as={FaSearch} color="gray.400" />
+              </InputLeftElement>
               <Input
-                type="search"
+                type="text"
                 placeholder="Search member"
+                value={searchQuery}
                 onChange={handleSearch}
               />
+              {searchQuery && (
+                <InputRightElement>
+                  <IconButton
+                    aria-label="Clear search"
+                    icon={<FiX />}
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => setSearchQuery("")}
+                  />
+                </InputRightElement>
+              )}
             </InputGroup>
-            {filterName.length === 0 && (
+            {filteredMembers.length === 0 && (
               <Box mt="4">
                 <Text ml="4" fontWeight="bold">
                   No member found
@@ -350,41 +335,18 @@ const MarkAttendance = () => {
             )}
             <Flex mt="2" justifyContent="space-between">
               <Text>
-                Present: <strong>{attendanceInfo?.present}</strong>
+                Present: <strong>{attendanceInfo.present}</strong>
               </Text>
               <Text>
-                Apology: <strong>{attendanceInfo?.apology}</strong>
+                Apology: <strong>{attendanceInfo.apology}</strong>
               </Text>
               <Text>
-                Absent: <strong>{attendanceInfo?.absent}</strong>
+                Absent: <strong>{attendanceInfo.absent}</strong>
               </Text>
             </Flex>
-            <Box mt="4" overflow="scroll" maxHeight="300px">
-              {filterName.map((item) => (
-                <Button
-                  key={item.id}
-                  variant="unstyled"
-                  onClick={() => updateAttendance(item.id)}
-                  display="block"
-                  w="full"
-                  mt="3"
-                  border="1px solid green"
-                  bg={
-                    item.attendanceStatus === "present"
-                      ? "green"
-                      : item.attendanceStatus === "apology"
-                      ? "orange"
-                      : ""
-                  }
-                  color={
-                    item.attendanceStatus === "present" ||
-                    item.attendanceStatus === "apology"
-                      ? "#fff"
-                      : ""
-                  }
-                >
-                  {item.name}
-                </Button>
+            <Box mt="4" overflow="auto" maxHeight="300px">
+              {filteredMembers.map((item) => (
+                <MemberRow key={item.id} member={item} onToggle={updateAttendance} />
               ))}
             </Box>
             <Button
@@ -392,7 +354,7 @@ const MarkAttendance = () => {
               w="full"
               mt="8"
               isLoading={isLoading}
-              disabled={attendanceInfo.present === 0}
+              isDisabled={attendanceInfo.present === 0}
             >
               {isUpdate ? "Update" : "Submit"}
             </Button>
@@ -401,7 +363,7 @@ const MarkAttendance = () => {
               w="full"
               variant="logout"
               mt="4"
-              disabled={isLoading}
+              isDisabled={isLoading}
             >
               Cancel
             </Button>

--- a/src/pages/Organisations.tsx
+++ b/src/pages/Organisations.tsx
@@ -20,16 +20,14 @@ import { FaTrashAlt } from "react-icons/fa";
 import { confirmAlert } from "react-confirm-alert";
 import { useState } from "react";
 import { orgRequest } from "services";
-import useGlobalStore, { EMPTY_USER } from "zStore";
+import useGlobalStore from "zStore";
 import SetEmailModal from "components/auth/SetEmailModal";
+import AppHeader from "components/AppHeader";
 import { OrganisationSummary } from "rbac/types";
 
 const OrgList = () => {
   const navigate = useNavigate();
-  const [setOrg, setUser] = useGlobalStore((state) => [
-    state.updateOrganisation,
-    state.setUser,
-  ]);
+  const [setOrg] = useGlobalStore((state) => [state.updateOrganisation]);
   const onSuccess = () => {
     refetch();
     queryClient.invalidateQueries({ queryKey: ["all-organisations"] });
@@ -79,20 +77,7 @@ const OrgList = () => {
   return (
     <Box minH={"100vh"} bg={useColorModeValue("gray.50", "gray.800")}>
       <SetEmailModal />
-      <Flex
-        bg="blue.500"
-        justifyContent="space-between"
-        alignItems="center"
-        p="4"
-      >
-        <Text color="#fff">Attendance Tracker</Text>
-        <Button
-        variant="logout"
-          onClick={() => setUser(EMPTY_USER)}
-        >
-          Logout
-        </Button>
-      </Flex>
+      <AppHeader />
       <Button  mt="4" ml="6" onClick={() => navigate(PROTECTED_PATHS.ADD_ORG)}>
         + Add Org
       </Button>

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -4,6 +4,7 @@ import {
 } from "@chakra-ui/react";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { Link as RouterLink, useNavigate, useSearchParams } from "react-router-dom";
+import PasswordInput from "components/PasswordInput";
 import { authRequest } from "services";
 import { postRequest, useMutationWrapper } from "services/api/apiHelper";
 import { PUBLIC_PATHS } from "routes/pagePath";
@@ -13,14 +14,17 @@ interface SignupInputs {
   username: string;
   email: string;
   password: string;
+  confirmPassword: string;
 }
+
+const PASSWORD_MIN_LENGTH = 6;
 
 const Signup = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const [setUser] = useGlobalStore((s) => [s.setUser]);
   const {
-    register, handleSubmit, formState: { errors },
+    register, handleSubmit, watch, formState: { errors },
   } = useForm<SignupInputs>({
     defaultValues: { email: searchParams.get("email") ?? "" },
   });
@@ -38,7 +42,7 @@ const Signup = () => {
   };
   const { mutate, isLoading } = useMutationWrapper(postRequest, onSuccess);
 
-  const onSubmit: SubmitHandler<SignupInputs> = (data) =>
+  const onSubmit: SubmitHandler<SignupInputs> = ({ confirmPassword, ...data }) =>
     mutate({ url: authRequest.SIGN_UP, data });
 
   return (
@@ -66,11 +70,29 @@ const Signup = () => {
               </FormControl>
               <FormControl isInvalid={!!errors.password}>
                 <FormLabel>Password</FormLabel>
-                <Input
-                  type="password"
-                  {...register("password", { required: "Password is required" })}
+                <PasswordInput
+                  autoComplete="new-password"
+                  {...register("password", {
+                    required: "Password is required",
+                    minLength: {
+                      value: PASSWORD_MIN_LENGTH,
+                      message: `Password must be at least ${PASSWORD_MIN_LENGTH} characters`,
+                    },
+                  })}
                 />
                 <FormErrorMessage>{errors.password?.message}</FormErrorMessage>
+              </FormControl>
+              <FormControl isInvalid={!!errors.confirmPassword}>
+                <FormLabel>Confirm password</FormLabel>
+                <PasswordInput
+                  autoComplete="new-password"
+                  {...register("confirmPassword", {
+                    required: "Please confirm your password",
+                    validate: (value) =>
+                      value === watch("password") || "Passwords do not match",
+                  })}
+                />
+                <FormErrorMessage>{errors.confirmPassword?.message}</FormErrorMessage>
               </FormControl>
               <Button type="submit" bg="blue.400" color="white" isLoading={isLoading} _hover={{ bg: "blue.500" }}>
                 Sign up

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,12 +1,29 @@
-import useGlobalStore from "zStore";
+import { useEffect } from "react";
+import useGlobalStore, { EMPTY_USER, EMPTY_ORG } from "zStore";
+import { isTokenExpired } from "utils/auth";
 import Authenticated from "./Authenticated";
 import UnAuthenticated from "./UnAuthenticated";
 
 const Pages = () => {
-  const [user] = useGlobalStore((state) => [state.user]);
+  const [user, setUser, updateOrganisation] = useGlobalStore((state) => [
+    state.user,
+    state.setUser,
+    state.updateOrganisation,
+  ]);
 
-  const isAuthUser = user.token !== "";
-  if (isAuthUser) {
+  const hasToken = user.token !== "";
+  const expired = hasToken && isTokenExpired(user.token);
+
+  // A persisted-but-expired token should never keep the user "logged in". Clear
+  // it so the store matches reality and we drop to the login screen.
+  useEffect(() => {
+    if (expired) {
+      setUser(EMPTY_USER);
+      updateOrganisation(EMPTY_ORG);
+    }
+  }, [expired, setUser, updateOrganisation]);
+
+  if (hasToken && !expired) {
     return <Authenticated />;
   }
 

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -6,6 +6,7 @@ import axios, {
 } from "axios";
 import { toast } from "react-toastify";
 import useGlobalStore, { EMPTY_USER } from "zStore";
+import { authRequest } from "./request";
 
 export const baseURL = process.env.REACT_APP_BASE_URL;
 export * from "./request";
@@ -42,7 +43,11 @@ const onResponseError = (error: AxiosError): Promise<AxiosError> => {
     const statusCode = error.response.status;
     const data = error.response.data as ErrorResponse;
     const errMsg = data.error || "Authentication Error";
-    if (statusCode === 401) {
+    // The change-password endpoint returns 401 for a wrong *current password* —
+    // a form error, not a dead session. Let ChangePasswordModal decide how to
+    // handle it instead of blindly logging the user out here.
+    const isUpdatePassword = error.config?.url?.endsWith(authRequest.UPDATE_PASSWORD);
+    if (statusCode === 401 && !isUpdatePassword) {
       // logout user
       toast.error(errMsg);
       useGlobalStore.setState({ user: EMPTY_USER });

--- a/src/services/api/request.ts
+++ b/src/services/api/request.ts
@@ -3,6 +3,7 @@ export const authRequest = {
   GET_ME: "/users/me",
   SIGN_UP: "/users/signup",
   SET_EMAIL: "/users/me/email",
+  UPDATE_PASSWORD: "/users/me/password",
   FORGOT_PASSWORD: "/users/forgot-password",
   RESET_PASSWORD: "/users/reset-password",
 };

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,45 @@
+/**
+ * Auth token helpers.
+ *
+ * The API issues stateless JWTs. Because the token is just a persisted string,
+ * the app can't tell an expired session from a live one by presence alone — so
+ * we decode the `exp` claim client-side to gate access without waiting for a
+ * server 401. The server's 401 (handled by the axios interceptor) remains the
+ * source of truth for revocation; this is a fast, offline-capable first check.
+ */
+
+interface JwtPayload {
+  exp?: number; // seconds since epoch
+}
+
+/** Decode a JWT payload without verifying the signature. Returns null if it isn't a decodable JWT. */
+const decodeJwtPayload = (token: string): JwtPayload | null => {
+  try {
+    const payload = token.split(".")[1];
+    if (!payload) return null;
+    const base64 = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const json = decodeURIComponent(
+      atob(base64)
+        .split("")
+        .map((char) => "%" + char.charCodeAt(0).toString(16).padStart(2, "0"))
+        .join("")
+    );
+    return JSON.parse(json) as JwtPayload;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * True only when the token can be decoded AND its `exp` is in the past.
+ *
+ * Deliberately conservative: an empty token, an opaque (non-JWT) token, or a
+ * JWT with no `exp` returns `false`. We never lock a user out over a token we
+ * can't read — the server's 401 covers those cases instead.
+ */
+export const isTokenExpired = (token: string): boolean => {
+  if (!token) return false;
+  const payload = decodeJwtPayload(token);
+  if (!payload?.exp) return false;
+  return Date.now() >= payload.exp * 1000;
+};


### PR DESCRIPTION
## Summary

A batch of account/auth UX improvements plus polish on the attendance screens.

### Account & auth
- **Change password** — new `ChangePasswordModal` (`PATCH /users/me/password`). Distinguishes a wrong *current password* `401` (inline field error, stays open) from an expired-session `401` (drops to login), and exempts the endpoint from the axios interceptor's blanket 401-logout so the form can recover.
- **Shared `AppHeader`** — responsive user dropdown (avatar + name; collapses to avatar-only on mobile) showing email + RBAC role, with change-password, back-to-organisations, and logout. Replaces the duplicated header bars on the Organisations and Dashboard screens.
- **Expired-token redirect** — decode the JWT `exp` client-side (`isTokenExpired`) and gate the app on token validity, clearing a stale persisted session so an expired token lands the user on login instead of lingering on store-rendered pages. Conservative: undecodable/opaque tokens fall back to the server's 401.
- **Password inputs** — reuse `PasswordInput` (eye-icon toggle) on Login and Signup; add a confirm-password field to Signup with match + min-length validation.

### Attendance screens
- **MarkAttendance** — replace the native search "X" with a search icon + custom clear button; align Refresh with the title; derive the filtered list and status counts via `useMemo` (removing hand-synced state), memoize member rows, and minor cleanups (remove `console.log`, `overflow: auto`, `isDisabled`).
- **AllAttendance** — remove the duplicated date; add a category badge, an "Edited" tag, and a single meta line `by <creator> · <event date> · <recorded time>`. Names use first-letter capitalization (preserves acronyms).

## Testing
- `tsc --noEmit` and ESLint clean across all changed files.
- Manual smoke test recommended: change-password wrong-current-password path (must NOT log out), mobile avatar collapse, RBAC role badge on Dashboard, and expired-token redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)