### PR TITLE
feat(analytics): improve table presentation and add range date picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "nanoid": "^4.0.2",
     "react": "^18.1.0",
     "react-confirm-alert": "^3.0.6",
+    "react-datepicker": "^4",
     "react-dom": "^18.1.0",
     "react-hook-form": "^7.43.9",
     "react-icon": "^1.0.0",
@@ -64,6 +65,7 @@
     ]
   },
   "devDependencies": {
+    "@types/react-datepicker": "^4.19.0",
     "@typescript-eslint/eslint-plugin": "^5.23.0",
     "@typescript-eslint/parser": "^5.23.0",
     "eslint": "^8.0.1",
@@ -81,6 +83,9 @@
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": "eslint --cache --fix",
     "*.{js,jsx,ts,tsx,css,md}": "prettier --write"
+  },
+  "resolutions": {
+    "@types/react": "^18.2.0"
   },
   "packageManager": "yarn@1.22.22"
 }

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -23,6 +23,8 @@ import { PROTECTED_PATHS } from "routes/pagePath";
 import { attendanceRequest, orgRequest } from "services";
 import { capitalize, convertParamsToString } from "helpers/stringManipulations";
 import ReactSelect, { MultiValue } from "react-select";
+import DatePicker from "react-datepicker";
+import "react-datepicker/dist/react-datepicker.css";
 import { toast } from "react-toastify";
 import {
   startOfMonth,
@@ -34,6 +36,7 @@ import {
   startOfYear,
   endOfYear,
   format,
+  parseISO,
 } from "date-fns";
 
 type StatusOption = {
@@ -42,6 +45,75 @@ type StatusOption = {
 };
 
 const DATE_INPUT_FORMAT = "yyyy-MM-dd";
+const DAY_HEADER_FORMAT = "EEE d, MMM"; // e.g. "Tue 3, Jul"
+
+// rotate narrow column headers so single-letter cells don't waste width.
+// applied to an inner span (not the th) so the cell stays in normal writing
+// mode and can center the label horizontally over its column.
+// keep the react-datepicker input full-width and vertically center its
+// clear (×) button, which otherwise sits misaligned against a Chakra input
+const DATE_PICKER_WRAPPER_SX = {
+  ".react-datepicker-wrapper": { width: "100%" },
+  ".react-datepicker__close-icon": {
+    top: 0,
+    right: "0.5rem",
+    marginRight: "0.5rem",
+    height: "100%",
+    display: "flex",
+    alignItems: "center",
+    padding: 0,
+  },
+  ".react-datepicker__close-icon::after": {
+    display: "block",
+    backgroundColor: "transparent",
+    color: "gray.400",
+    height: "auto",
+    width: "auto",
+    padding: 0,
+    fontSize: "20px",
+    lineHeight: 1,
+  },
+  ".react-datepicker__close-icon:hover::after": {
+    color: "gray.600",
+  },
+} as const;
+
+const VERTICAL_LABEL_SX = {
+  display: "inline-block",
+  writingMode: "vertical-rl",
+  transform: "rotate(180deg)",
+  whiteSpace: "nowrap",
+} as const;
+
+type AttendanceStatus = "present" | "absent" | "apology";
+
+const STATUS_META: Record<
+  AttendanceStatus,
+  { color: string; short: string; full: string }
+> = {
+  present: { color: "green", short: "P", full: "Present" },
+  absent: { color: "red", short: "A", full: "Absent" },
+  apology: { color: "yellow", short: "AP", full: "Apology" },
+};
+
+const EMPTY_STATUS_META = { color: "gray", short: "-", full: "No record" };
+
+const getStatusMeta = (status: string | undefined) =>
+  STATUS_META[status as AttendanceStatus] ?? EMPTY_STATUS_META;
+
+// extract the yyyy-MM-dd suffix from a date column key and render it compactly
+const formatDayHeader = (key: string) => {
+  const isoDate = key.match(/\d{4}-\d{2}-\d{2}$/)?.[0];
+  return isoDate ? format(parseISO(isoDate), DAY_HEADER_FORMAT) : key;
+};
+
+const formatRangeLabel = (fromISO: string, toISO: string) => {
+  const from = parseISO(fromISO);
+  const to = parseISO(toISO);
+  const sameYear = from.getFullYear() === to.getFullYear();
+  const fromLabel = format(from, sameYear ? "MMM d" : "MMM d, yyyy");
+  return `${fromLabel} – ${format(to, "MMM d, yyyy")}`;
+};
 
 const DATE_PRESETS: {
   label: string;
@@ -79,6 +151,7 @@ const AttendanceAnalyticsPage: React.FC = () => {
   const [org] = useGlobalStore((state) => [state.organisation]);
   const [fromDate, setFromDate] = useState<string>("");
   const [toDate, setToDate] = useState<string>("");
+  const [activePreset, setActivePreset] = useState<string | null>(null);
   const [hasSearched, setHasSearched] = useState(false);
   const [statusFilter, setStatusFilter] = useState<string[]>(["all"]);
   const [statusOptions, setStatusOptions] = useState<string[]>([
@@ -142,7 +215,7 @@ const AttendanceAnalyticsPage: React.FC = () => {
     const queryParams = new URLSearchParams({
       fromDate,
       toDate,
-      sort: "present:desc",
+      sort: "ranking",
     });
 
     if (selectedStatuses.length) {
@@ -213,7 +286,7 @@ const AttendanceAnalyticsPage: React.FC = () => {
       {
         enabled: false,
         onSuccess: (response: any) => handleExportSuccess(response, "Excel"),
-      onError: (err: any) => handleExportError(err, "Excel"),
+        onError: (err: any) => handleExportError(err, "Excel"),
       },
     );
 
@@ -240,12 +313,27 @@ const AttendanceAnalyticsPage: React.FC = () => {
     }
   };
 
-  const applyPreset = (getRange: (today: Date) => { from: Date; to: Date }) => {
-    const { from, to } = getRange(new Date());
+  const applyPreset = (preset: (typeof DATE_PRESETS)[number]) => {
+    const { from, to } = preset.getRange(new Date());
     setFromDate(format(from, DATE_INPUT_FORMAT));
     setToDate(format(to, DATE_INPUT_FORMAT));
+    setActivePreset(preset.label);
     setHasSearched(false);
   };
+
+  const handleDateChange =
+    (setter: (value: string) => void) => (date: Date | null) => {
+      setter(date ? format(date, DATE_INPUT_FORMAT) : "");
+      setActivePreset(null);
+      setHasSearched(false);
+    };
+
+  const fromDateValue = fromDate ? parseISO(fromDate) : null;
+  const toDateValue = toDate ? parseISO(toDate) : null;
+  // attendance can't exist in the future, so cap both pickers at today
+  const today = new Date();
+  const fromMaxDate =
+    toDateValue && toDateValue < today ? toDateValue : today;
 
   // pull out keys & data rows
   const keys: string[] = useMemo(
@@ -338,17 +426,21 @@ const AttendanceAnalyticsPage: React.FC = () => {
           </Flex>
           {/* Quick date range presets */}
           <Flex mb={3} gap={2} flexWrap="wrap">
-            {DATE_PRESETS.map((preset) => (
-              <Button
-                key={preset.label}
-                size="sm"
-                variant="outline"
-                colorScheme="blue"
-                onClick={() => applyPreset(preset.getRange)}
-              >
-                {preset.label}
-              </Button>
-            ))}
+            {DATE_PRESETS.map((preset) => {
+              const isActive = activePreset === preset.label;
+              return (
+                <Button
+                  key={preset.label}
+                  size="sm"
+                  variant={isActive ? "solid" : "outline"}
+                  colorScheme="blue"
+                  aria-pressed={isActive}
+                  onClick={() => applyPreset(preset)}
+                >
+                  {preset.label}
+                </Button>
+              );
+            })}
           </Flex>
 
           {/* Date selectors + button */}
@@ -358,26 +450,35 @@ const AttendanceAnalyticsPage: React.FC = () => {
             align="center"
             direction={{ base: "column", md: "row" }}
           >
-            <Input
-              type="date"
-              value={fromDate}
-              onChange={(e) => {
-                setFromDate(e.target.value);
-                setHasSearched(false);
-              }}
-              w={{ base: "100%", md: "auto" }}
-              max={toDate || undefined}
-            />
-            <Input
-              type="date"
-              value={toDate}
-              onChange={(e) => {
-                setToDate(e.target.value);
-                setHasSearched(false);
-              }}
-              w={{ base: "100%", md: "auto" }}
-              min={fromDate || undefined}
-            />
+            <Box w={{ base: "100%", md: "auto" }} sx={DATE_PICKER_WRAPPER_SX}>
+              <DatePicker
+                selected={fromDateValue}
+                onChange={handleDateChange(setFromDate)}
+                selectsStart
+                startDate={fromDateValue}
+                endDate={toDateValue}
+                maxDate={fromMaxDate}
+                dateFormat="MMM d, yyyy"
+                placeholderText="From date"
+                isClearable
+                customInput={<Input pr="2rem" />}
+              />
+            </Box>
+            <Box w={{ base: "100%", md: "auto" }} sx={DATE_PICKER_WRAPPER_SX}>
+              <DatePicker
+                selected={toDateValue}
+                onChange={handleDateChange(setToDate)}
+                selectsEnd
+                startDate={fromDateValue}
+                endDate={toDateValue}
+                minDate={fromDateValue ?? undefined}
+                maxDate={today}
+                dateFormat="MMM d, yyyy"
+                placeholderText="To date"
+                isClearable
+                customInput={<Input pr="2rem" />}
+              />
+            </Box>
             <Box w={{ base: "100%", md: "260px" }}>
               <ReactSelect
                 isMulti
@@ -427,68 +528,83 @@ const AttendanceAnalyticsPage: React.FC = () => {
 
           {/* Table */}
           {!isFetching && !error && hasSearched && rows.length > 0 && (
-            <Box overflowX="auto">
-              <Table variant="striped" size="sm">
-                <Thead>
-                  <Tr>
-                    <Th isNumeric>SN</Th>
-                    <Th>Name</Th>
-                    {totalKeys.map((label) => (
-                      <Th key={label} isNumeric>
-                        {label}
-                      </Th>
-                    ))}
-                    {dateKeys.map((d) => (
-                      <Th key={d}>{d.split(" On ")[1]}</Th>
-                    ))}
-                  </Tr>
-                </Thead>
-                <Tbody>
-                  {rows.map((row, index) => (
-                    <Tr key={row.memberId}>
-                      <Td isNumeric>{index + 1}</Td>
-                      <Td>{row.name}</Td>
+            <Box>
+              {/* Applied range + status legend */}
+              <Flex
+                mb={3}
+                gap={3}
+                align="center"
+                justify="space-between"
+                flexWrap="wrap"
+              >
+                <Text fontWeight="semibold">
+                  {formatRangeLabel(fromDate, toDate)}
+                </Text>
+                <Flex gap={4} flexWrap="wrap">
+                  {(Object.keys(STATUS_META) as AttendanceStatus[]).map(
+                    (status) => (
+                      <Flex key={status} align="center" gap={1}>
+                        <Badge colorScheme={STATUS_META[status].color}>
+                          {STATUS_META[status].short}
+                        </Badge>
+                        <Text fontSize="sm">{STATUS_META[status].full}</Text>
+                      </Flex>
+                    ),
+                  )}
+                </Flex>
+              </Flex>
 
+              <Box overflowX="auto">
+                <Table variant="striped" size="sm">
+                  <Thead>
+                    <Tr>
+                      <Th isNumeric>SN</Th>
+                      <Th>Name</Th>
                       {totalKeys.map((label) => (
-                        <Td key={label} isNumeric>
-                          {row[totalsMap[label]]}
-                        </Td>
+                        <Th key={label} textAlign="center" verticalAlign="bottom">
+                          <Box as="span" sx={VERTICAL_LABEL_SX}>
+                            {label}
+                          </Box>
+                        </Th>
                       ))}
-
-                      {dateKeys.map((d) => {
-                        const status = row[d] as string as
-                          | "present"
-                          | "absent"
-                          | "apology"
-                          | undefined;
-                        let color: string, label: string;
-                        switch (status) {
-                          case "present":
-                            color = "green";
-                            label = "P";
-                            break;
-                          case "absent":
-                            color = "red";
-                            label = "A";
-                            break;
-                          case "apology":
-                            color = "yellow";
-                            label = "AP";
-                            break;
-                          default:
-                            color = "gray";
-                            label = "-";
-                        }
-                        return (
-                          <Td key={d} textAlign="center">
-                            <Badge colorScheme={color}>{label}</Badge>
-                          </Td>
-                        );
-                      })}
+                      {dateKeys.map((d) => (
+                        <Th key={d} textAlign="center" verticalAlign="bottom">
+                          <Box as="span" sx={VERTICAL_LABEL_SX}>
+                            {formatDayHeader(d)}
+                          </Box>
+                        </Th>
+                      ))}
                     </Tr>
-                  ))}
-                </Tbody>
-              </Table>
+                  </Thead>
+                  <Tbody>
+                    {rows.map((row, index) => (
+                      <Tr key={row.memberId}>
+                        <Td isNumeric>{index + 1}</Td>
+                        <Td>{row.name}</Td>
+
+                        {totalKeys.map((label) => (
+                          <Td key={label} textAlign="center">
+                            <Badge
+                              colorScheme={getStatusMeta(label.toLowerCase()).color}
+                            >
+                              {row[totalsMap[label]] ?? 0}
+                            </Badge>
+                          </Td>
+                        ))}
+
+                        {dateKeys.map((d) => {
+                          const meta = getStatusMeta(row[d] as string);
+                          return (
+                            <Td key={d} textAlign="center">
+                              <Badge colorScheme={meta.color}>{meta.short}</Badge>
+                            </Td>
+                          );
+                        })}
+                      </Tr>
+                    ))}
+                  </Tbody>
+                </Table>
+              </Box>
             </Box>
           )}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2372,6 +2372,11 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
+"@popperjs/core@^2.11.8", "@popperjs/core@^2.9.2":
+  version "2.11.8"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
+  integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
+
 "@popperjs/core@^2.9.3":
   version "2.11.5"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
@@ -2869,6 +2874,16 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
+"@types/react-datepicker@^4.19.0":
+  version "4.19.6"
+  resolved "https://registry.yarnpkg.com/@types/react-datepicker/-/react-datepicker-4.19.6.tgz#3095fb3c4b38b598c7e3104d73d246c9b4eddb19"
+  integrity sha512-uH5fzxt9eXxnc+hDCy/iRSFqU2+9lR/q2lAmaG4WILMai1o3IOdpcV+VSypzBFJLTEC2jrfeDXcdol0CJVMq4g==
+  dependencies:
+    "@popperjs/core" "^2.9.2"
+    "@types/react" "*"
+    date-fns "^2.0.1"
+    react-popper "^2.2.5"
+
 "@types/react-dom@^18.0.0":
   version "18.0.4"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.4.tgz#dcbcadb277bcf6c411ceff70069424c57797d375"
@@ -2886,16 +2901,7 @@
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.12.tgz#b5d76568485b02a307238270bfe96cb51ee2a044"
   integrity sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==
 
-"@types/react@*":
-  version "18.0.9"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.9.tgz#d6712a38bd6cd83469603e7359511126f122e878"
-  integrity sha512-9bjbg1hJHUm4De19L1cHiW0Jvx3geel6Qczhjd0qY5VKVE2X5+x77YxAepuCwVh4vrgZJdgEJw48zrhRIeF4Nw==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^18.2.0":
+"@types/react@*", "@types/react@^18.2.0":
   version "18.3.28"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.28.tgz#0a85b1a7243b4258d9f626f43797ba18eb5f8781"
   integrity sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==
@@ -2914,11 +2920,6 @@
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
-
-"@types/scheduler@*":
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
-  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
 "@types/serve-index@^1.9.1":
   version "1.9.1"
@@ -4065,6 +4066,11 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
+classnames@^2.2.6:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
+
 clean-css@^5.2.2:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.3.0.tgz#ad3d8238d5f3549e83d5f87205189494bc7cbb59"
@@ -4618,17 +4624,17 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-date-fns@^2.29.3:
-  version "2.29.3"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
-  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
-
-date-fns@^2.30.0:
+date-fns@^2.0.1, date-fns@^2.30.0:
   version "2.30.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
   integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
   dependencies:
     "@babel/runtime" "^7.21.0"
+
+date-fns@^2.29.3:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
 debug@*, debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3:
   version "4.3.4"
@@ -9050,7 +9056,7 @@ prompts@^2.0.1, prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.8.1:
+prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -9169,6 +9175,18 @@ react-confirm-alert@^3.0.6:
   resolved "https://registry.yarnpkg.com/react-confirm-alert/-/react-confirm-alert-3.0.6.tgz#f7552ec839c1e189370cef02ffed3035e7ca2e22"
   integrity sha512-rplP6Ed9ZSNd0KFV5BUzk4EPQ77BxsrayllBXGFuA8xPXc7sbBjgU5KUrNpl7aWFmP7mXRlVXfuy1IT5DbffYw==
 
+react-datepicker@^4:
+  version "4.25.0"
+  resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-4.25.0.tgz#86b3ee8ac764bad1650046d0cf9280837bf6d845"
+  integrity sha512-zB7CSi44SJ0sqo8hUQ3BF1saE/knn7u25qEMTO1CQGofY1VAKahO8k9drZtp0cfW1DMfoYLR3uSY1/uMvbEzbg==
+  dependencies:
+    "@popperjs/core" "^2.11.8"
+    classnames "^2.2.6"
+    date-fns "^2.30.0"
+    prop-types "^15.7.2"
+    react-onclickoutside "^6.13.0"
+    react-popper "^2.3.0"
+
 react-dev-utils@^12.0.1:
   version "12.0.1"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-12.0.1.tgz#ba92edb4a1f379bd46ccd6bcd4e7bc398df33e73"
@@ -9217,6 +9235,11 @@ react-fast-compare@3.2.0:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
+react-fast-compare@^3.0.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
+  integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
+
 react-focus-lock@^2.9.1:
   version "2.9.1"
   resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.9.1.tgz#094cfc19b4f334122c73bb0bff65d77a0c92dd16"
@@ -9258,6 +9281,19 @@ react-is@^18.0.0:
   version "18.1.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.1.0.tgz#61aaed3096d30eacf2a2127118b5b41387d32a67"
   integrity sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==
+
+react-onclickoutside@^6.13.0:
+  version "6.13.2"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.13.2.tgz#caa6df2c0cfe017506548fa810303fb85d13fb7c"
+  integrity sha512-h6Hbf1c8b7tIYY4u90mDdBLY4+AGQVMFtIE89HgC0DtVCh/JfKl477gYqUtGLmjZBKK3MJxomP/lFiLbz4sq9A==
+
+react-popper@^2.2.5, react-popper@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.3.0.tgz#17891c620e1320dce318bad9fede46a5f71c70ba"
+  integrity sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==
+  dependencies:
+    react-fast-compare "^3.0.1"
+    warning "^4.0.2"
 
 react-refresh@^0.11.0:
   version "0.11.0"
@@ -10874,6 +10910,13 @@ walker@^1.0.7:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
+
+warning@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
 
 watchpack@^2.3.1:
   version "2.3.1"


### PR DESCRIPTION
## Summary

Improves the Attendance Analytics page presentation and replaces the native date inputs with a proper range-aware date picker.

### Table presentation
- Compact day headers (`Tue 3, Jul`) instead of raw ISO dates like `2026-07-03`, plus a once-shown applied-range label (e.g. `Jul 3 – Jul 31, 2026`) above the table.
- Present/Absent/Apology and per-day column headers now render **vertically**, so single-letter status cells (P/A/AP) no longer waste horizontal space.
- Colored total chips and a status legend (P = Present, A = Absent, AP = Apology), all driven by a single shared `STATUS_META` map (replaces the previous inline `switch`).

### Date range UX
- `react-datepicker` for From/To, range-aware via `selectsStart`/`selectsEnd` + `min`/`max` linking so each calendar highlights the span and blocks invalid picks.
- Both pickers are capped at **today** — attendance can't be queried into the future.
- Restyled the clear (×) button to match the status picker's clear icon.
- Active-state highlight on the quick-range preset buttons (This Month, Last Month, …).

### Dependencies
- Adds `react-datepicker@4` + matching `@types/react-datepicker`.
- Pins `@types/react` via `resolutions` to dedupe a nested copy that otherwise broke DatePicker's JSX types under yarn.

## Testing
- `tsc --noEmit` passes.
- Manually verified in-browser: range highlighting, future-date blocking, clear-button alignment, preset active state.

## Notes
The picker styling currently lives inline on the Analytics page by design — once reviewed, the plan is to extract a reusable `<DateRangePicker>` and roll it out to the other pages still using native date inputs (Birthday, CreateAttendance, finance tabs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)