### PR TITLE
feat: use 'Mon Jun 29, 26' date format on member analytics page

### DIFF
--- a/src/components/analytics/AttendanceTimeline.tsx
+++ b/src/components/analytics/AttendanceTimeline.tsx
@@ -3,6 +3,7 @@ import { Box, Flex, Text, Tooltip, Wrap, WrapItem } from "@chakra-ui/react";
 import { format, parseISO } from "date-fns";
 import { MemberVerdict } from "components/analytics/memberAnalyticsTypes";
 import { getStatusMeta, STATUS_META, AttendanceStatus } from "components/analytics/statusMeta";
+import { FULL_DATE_FORMAT } from "components/analytics/dateFormats";
 
 const cellColor = (status: AttendanceStatus) => `${getStatusMeta(status).color}.500`;
 
@@ -32,7 +33,7 @@ const AttendanceTimeline: React.FC<{ verdicts: MemberVerdict[] }> = ({ verdicts 
             {group.items.map((verdict, index) => (
               <WrapItem key={`${verdict.date}-${verdict.status}-${index}`}>
                 <Tooltip
-                  label={`${format(parseISO(verdict.date), "MMM d, yyyy")} · ${getStatusMeta(verdict.status).full}`}
+                  label={`${format(parseISO(verdict.date), FULL_DATE_FORMAT)} · ${getStatusMeta(verdict.status).full}`}
                 >
                   <Box
                     data-cell="verdict" w="16px" h="16px" borderRadius="4px"

--- a/src/components/analytics/MemberRecordsTable.tsx
+++ b/src/components/analytics/MemberRecordsTable.tsx
@@ -3,6 +3,7 @@ import { Box, Table, Thead, Tbody, Tr, Th, Td, Badge, Text } from "@chakra-ui/re
 import { format, parseISO } from "date-fns";
 import { MemberRecord } from "components/analytics/memberAnalyticsTypes";
 import { getStatusMeta } from "components/analytics/statusMeta";
+import { FULL_DATE_FORMAT } from "components/analytics/dateFormats";
 
 const MemberRecordsTable: React.FC<{ records: MemberRecord[] }> = ({ records }) => (
   <Box bg="white" borderRadius="12px" border="1px solid" borderColor="gray.200" p={2} overflowX="auto">
@@ -23,7 +24,7 @@ const MemberRecordsTable: React.FC<{ records: MemberRecord[] }> = ({ records }) 
           return (
             <Tr key={record.attendanceId}>
               <Td isNumeric>{index + 1}</Td>
-              <Td>{format(parseISO(record.date), "MMM d, yyyy")}</Td>
+              <Td>{format(parseISO(record.date), FULL_DATE_FORMAT)}</Td>
               <Td>{record.sessionName}</Td>
               <Td><Badge colorScheme={meta.color}>{meta.full}</Badge></Td>
               <Td>{record.hasBeenUpdated && <Badge colorScheme="purple">edited</Badge>}</Td>

--- a/src/components/analytics/dateFormats.ts
+++ b/src/components/analytics/dateFormats.ts
@@ -1,0 +1,3 @@
+// Full date display on the member analytics page, e.g. "Mon Jun 29, 26".
+// date-fns tokens: EEE = short weekday, MMM = short month, d = day, yy = 2-digit year.
+export const FULL_DATE_FORMAT = "EEE MMM d, yy";


### PR DESCRIPTION
Follow-up to #47 (already merged).

Standardizes the full-date display on the member analytics page to **`Mon Jun 29, 26`** (`EEE MMM d, yy`):
- Records-table Date column
- Timeline hover tooltips

Both now read from a shared `FULL_DATE_FORMAT` constant (`src/components/analytics/dateFormats.ts`) so the format has a single source of truth. Month-group headers on the timeline are unchanged.

Verified: analytics component tests + App test pass, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)