### PR TITLE
Editable attendance session details + org logo display

### DIFF
--- a/docs/superpowers/plans/2026-07-14-editable-attendance-details-and-org-image.md
+++ b/docs/superpowers/plans/2026-07-14-editable-attendance-details-and-org-image.md
@@ -1,0 +1,750 @@
+# Editable Attendance Session Details + Org Image Display Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users edit an attendance session's name/category/sub-category/date on the edit screen (via one shared form component reused by the create screen), and make a saved org logo URL actually render.
+
+**Architecture:** Extract a presentational, controlled `AttendanceDetailsForm` and a `useCategories` hook; both the create screen and the edit screen own their own state and feed the shared component. The edit screen writes changes into the existing `currentAttendance` store, which the existing `PUT` submit path already sends. Org image is a two-line display fix (avatar `src` + settings preview).
+
+**Tech Stack:** React 18 + TS strict, Chakra UI v2, Zustand (persisted), React Query v4, react-hook-form v7 (create/settings only — the shared component is plain controlled inputs), react-toastify, Jest + @testing-library/react.
+
+## Global Constraints
+
+- **No i18n** — hardcoded JSX copy, matching the codebase.
+- **No yup/zod** — validation is inline / manual.
+- **Dates are `"YYYY-MM-DD"` strings** everywhere; the date input is capped at today (`max`).
+- **`AttendanceDetailsForm` is presentational and fully controlled** — no data fetching, no persistence, no submit button; every edit calls `onChange` with the next full value; changing the category resets `subCategoryId` to `""`.
+- **No new endpoints** — `PUT /attendance/:id` already accepts `name/date/categoryId/subCategoryId`.
+- **No image upload** — logo is a URL string only.
+- Run green before each commit: `npx tsc --noEmit` and `CI=true yarn test --watchAll=false`. (If a test run errors with `EPERM ... /.npmrc`, that is a local sandbox restriction, not a code failure — re-run outside the sandbox.)
+
+---
+
+### Task 1: Shared foundation — `useCategories` hook + date-type fix
+
+**Files:**
+- Create: `src/hooks/useCategories.ts`
+- Test: `src/hooks/useCategories.test.tsx`
+- Modify: `src/pages/SubCategory.tsx:23` (import `CategoryType` from the hook)
+- Modify: `src/zStore.ts:5-11` (`currentAttendanceType.date`), `src/zStore.ts:69-75` (default)
+
+**Interfaces:**
+- Produces:
+  - `interface CommonTypeCategory { name: string; status: string; id: string; }`
+  - `interface SubCategoryType extends CommonTypeCategory { parentCategoryId: string; }`
+  - `interface CategoryType extends CommonTypeCategory { subCategories: SubCategoryType[]; }`
+  - `useCategories(organisationId: string): { categories: CategoryType[]; isLoading: boolean }`
+  - `currentAttendanceType.date` becomes `string` (was `Date`).
+
+- [ ] **Step 1: Write the failing hook test (via a probe component — RTL-version-agnostic)**
+
+Create `src/hooks/useCategories.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { queryClient } from "services/api/apiHelper";
+import { useCategories } from "hooks/useCategories";
+
+jest.mock("services/api", () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(() =>
+      Promise.resolve({
+        data: {
+          data: [
+            { id: "c1", name: "Sunday Service", status: "active", subCategories: [] },
+          ],
+        },
+      }),
+    ),
+  },
+}));
+
+function Probe({ orgId }: { orgId: string }) {
+  const { categories } = useCategories(orgId);
+  return <div>count:{categories.length}</div>;
+}
+
+it("returns the fetched categories", async () => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <Probe orgId="org1" />
+    </QueryClientProvider>,
+  );
+  expect(await screen.findByText("count:1")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `CI=true yarn test src/hooks/useCategories.test.tsx --watchAll=false`
+Expected: FAIL — "Cannot find module 'hooks/useCategories'".
+
+- [ ] **Step 3: Create the hook**
+
+Create `src/hooks/useCategories.ts`:
+
+```ts
+import { useState } from "react";
+import { useQueryWrapper } from "services/api/apiHelper";
+import { convertParamsToString } from "helpers/stringManipulations";
+import { orgRequest } from "services/api/request";
+
+export interface CommonTypeCategory {
+  name: string;
+  status: string;
+  id: string;
+}
+
+export interface SubCategoryType extends CommonTypeCategory {
+  parentCategoryId: string;
+}
+
+export interface CategoryType extends CommonTypeCategory {
+  subCategories: SubCategoryType[];
+}
+
+/**
+ * Fetches the org's categories (with nested sub-categories). Shared by the
+ * create and edit attendance screens. Uses the existing "get-all-category"
+ * query key so React Query dedupes across screens.
+ */
+export const useCategories = (organisationId: string) => {
+  const [categories, setCategories] = useState<CategoryType[]>([]);
+  const url = convertParamsToString(orgRequest.CATEGORY, { organisationId });
+  const { isLoading } = useQueryWrapper(["get-all-category"], url, {
+    enabled: Boolean(organisationId),
+    onSuccess: (res: { data: CategoryType[] }) => setCategories(res.data),
+  });
+  return { categories, isLoading };
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `CI=true yarn test src/hooks/useCategories.test.tsx --watchAll=false`
+Expected: PASS.
+
+- [ ] **Step 5: Point `SubCategory` at the shared type**
+
+In `src/pages/SubCategory.tsx`, change the import (line 23) from:
+
+```ts
+import { CategoryType } from "./CreateAttendance";
+```
+
+to:
+
+```ts
+import { CategoryType } from "hooks/useCategories";
+```
+
+(SubCategory keeps its own inline category query — not in scope to refactor — only its type import moves.)
+
+- [ ] **Step 6: Correct the `currentAttendanceType.date` type**
+
+In `src/zStore.ts`, change the `date` field of `currentAttendanceType` (line 9) from `date: Date;` to:
+
+```ts
+  date: string;
+```
+
+and change the store default (line 73) from `date: new Date(),` to:
+
+```ts
+    date: "",
+```
+
+(The app already stores/sends `date` as a `"YYYY-MM-DD"` string — this removes the type-vs-reality gap so later tasks need no casts.)
+
+- [ ] **Step 7: Typecheck and run the full suite**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+Run: `CI=true yarn test --watchAll=false`
+Expected: all PASS (existing suite + the new hook test).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/hooks/useCategories.ts src/hooks/useCategories.test.tsx src/pages/SubCategory.tsx src/zStore.ts
+git commit -m "feat: add useCategories hook and correct currentAttendance date type"
+```
+
+---
+
+### Task 2: `AttendanceDetailsForm` shared component
+
+**Files:**
+- Create: `src/components/attendance/AttendanceDetailsForm.tsx`
+- Test: `src/components/attendance/AttendanceDetailsForm.test.tsx`
+
+**Interfaces:**
+- Consumes: `CategoryType` from `hooks/useCategories` (Task 1).
+- Produces:
+  - `interface AttendanceDetails { name: string; categoryId: string; subCategoryId: string; date: string; }`
+  - default export `AttendanceDetailsForm` with props `{ value: AttendanceDetails; onChange: (next: AttendanceDetails) => void; categories: CategoryType[]; }`.
+
+- [ ] **Step 1: Write the failing component test**
+
+Create `src/components/attendance/AttendanceDetailsForm.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent } from "@testing-library/react";
+import AttendanceDetailsForm, {
+  AttendanceDetails,
+} from "components/attendance/AttendanceDetailsForm";
+import { CategoryType } from "hooks/useCategories";
+
+const categories: CategoryType[] = [
+  {
+    id: "c1",
+    name: "Sunday Service",
+    status: "active",
+    subCategories: [
+      { id: "s1", name: "First Mass", status: "active", parentCategoryId: "c1" },
+      { id: "s2", name: "Second Mass", status: "active", parentCategoryId: "c1" },
+    ],
+  },
+  { id: "c2", name: "Weekday", status: "active", subCategories: [] },
+];
+
+const base: AttendanceDetails = { name: "", categoryId: "", subCategoryId: "", date: "" };
+
+it("renders all four fields", () => {
+  render(<AttendanceDetailsForm value={base} onChange={() => {}} categories={categories} />);
+  expect(screen.getByLabelText("Name")).toBeInTheDocument();
+  expect(screen.getByLabelText("Category")).toBeInTheDocument();
+  expect(screen.getByLabelText("Sub Category")).toBeInTheDocument();
+  expect(screen.getByLabelText("Date")).toBeInTheDocument();
+});
+
+it("shows sub-categories of the selected category", () => {
+  render(
+    <AttendanceDetailsForm
+      value={{ ...base, categoryId: "c1" }}
+      onChange={() => {}}
+      categories={categories}
+    />,
+  );
+  expect(screen.getByRole("option", { name: "First Mass" })).toBeInTheDocument();
+  expect(screen.getByRole("option", { name: "Second Mass" })).toBeInTheDocument();
+});
+
+it("clears the sub-category when the category changes", () => {
+  const onChange = jest.fn();
+  render(
+    <AttendanceDetailsForm
+      value={{ ...base, categoryId: "c1", subCategoryId: "s1" }}
+      onChange={onChange}
+      categories={categories}
+    />,
+  );
+  fireEvent.change(screen.getByLabelText("Category"), { target: { value: "c2" } });
+  expect(onChange).toHaveBeenCalledWith(
+    expect.objectContaining({ categoryId: "c2", subCategoryId: "" }),
+  );
+});
+
+it("emits name edits", () => {
+  const onChange = jest.fn();
+  render(<AttendanceDetailsForm value={base} onChange={onChange} categories={categories} />);
+  fireEvent.change(screen.getByLabelText("Name"), { target: { value: "First Mass" } });
+  expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ name: "First Mass" }));
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `CI=true yarn test src/components/attendance/AttendanceDetailsForm.test.tsx --watchAll=false`
+Expected: FAIL — "Cannot find module 'components/attendance/AttendanceDetailsForm'".
+
+- [ ] **Step 3: Create the component**
+
+Create `src/components/attendance/AttendanceDetailsForm.tsx`:
+
+```tsx
+import { FormControl, FormLabel, Input, Select, Stack } from "@chakra-ui/react";
+import { CategoryType } from "hooks/useCategories";
+
+export interface AttendanceDetails {
+  name: string;
+  categoryId: string;
+  subCategoryId: string;
+  date: string; // YYYY-MM-DD
+}
+
+interface AttendanceDetailsFormProps {
+  value: AttendanceDetails;
+  onChange: (next: AttendanceDetails) => void;
+  categories: CategoryType[];
+}
+
+const AttendanceDetailsForm = ({
+  value,
+  onChange,
+  categories,
+}: AttendanceDetailsFormProps) => {
+  const subCategories =
+    categories.find((c) => c.id === value.categoryId)?.subCategories ?? [];
+  const today = new Date().toISOString().slice(0, 10);
+
+  return (
+    <Stack spacing={4}>
+      <FormControl id="name" isRequired>
+        <FormLabel mb="0">Name</FormLabel>
+        <Input
+          type="text"
+          placeholder="Attendance Name"
+          value={value.name}
+          onChange={(e) => onChange({ ...value, name: e.target.value })}
+        />
+      </FormControl>
+
+      <FormControl id="category">
+        <FormLabel mb="0">Category</FormLabel>
+        <Select
+          placeholder="Select option"
+          value={value.categoryId}
+          onChange={(e) =>
+            // Changing the category invalidates any previously chosen sub-category.
+            onChange({ ...value, categoryId: e.target.value, subCategoryId: "" })
+          }
+        >
+          {categories.map((category) => (
+            <option key={category.id} value={category.id}>
+              {category.name}
+            </option>
+          ))}
+        </Select>
+      </FormControl>
+
+      <FormControl id="subCategory">
+        <FormLabel mb="0">Sub Category</FormLabel>
+        <Select
+          placeholder="Select option"
+          value={value.subCategoryId}
+          isDisabled={subCategories.length === 0}
+          onChange={(e) => onChange({ ...value, subCategoryId: e.target.value })}
+        >
+          {subCategories.map((sub) => (
+            <option key={sub.id} value={sub.id}>
+              {sub.name}
+            </option>
+          ))}
+        </Select>
+      </FormControl>
+
+      <FormControl id="date" isRequired>
+        <FormLabel mb="0">Date</FormLabel>
+        <Input
+          type="date"
+          max={today}
+          value={value.date}
+          onChange={(e) => onChange({ ...value, date: e.target.value })}
+        />
+      </FormControl>
+    </Stack>
+  );
+};
+
+export default AttendanceDetailsForm;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `CI=true yarn test src/components/attendance/AttendanceDetailsForm.test.tsx --watchAll=false`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/attendance/AttendanceDetailsForm.tsx src/components/attendance/AttendanceDetailsForm.test.tsx
+git commit -m "feat: add shared AttendanceDetailsForm component"
+```
+
+---
+
+### Task 3: Refactor `CreateAttendance` onto the shared hook + component
+
+**Files:**
+- Modify: `src/pages/CreateAttendance.tsx` (replace inline form + query; keep behavior)
+
+**Interfaces:**
+- Consumes: `useCategories` (Task 1), `AttendanceDetailsForm` + `AttendanceDetails` (Task 2).
+
+- [ ] **Step 1: Rewrite the component**
+
+Replace the entire contents of `src/pages/CreateAttendance.tsx` with:
+
+```tsx
+import {
+  Box,
+  Flex,
+  useColorModeValue,
+  Text,
+  Button,
+  Stack,
+} from "@chakra-ui/react";
+import { useNavigate } from "react-router-dom";
+import { PROTECTED_PATHS } from "routes/pagePath";
+import useGlobalStore, { currentAttendanceType } from "zStore";
+import { queryClient } from "services/api/apiHelper";
+import { Q_KEY } from "utils/constant";
+import { FaArrowCircleLeft } from "react-icons/fa";
+import { useState } from "react";
+import { toast } from "react-toastify";
+import { useCategories } from "hooks/useCategories";
+import AttendanceDetailsForm, {
+  AttendanceDetails,
+} from "components/attendance/AttendanceDetailsForm";
+
+const EMPTY_DETAILS: AttendanceDetails = {
+  name: "",
+  categoryId: "",
+  subCategoryId: "",
+  date: "",
+};
+
+const CreateAttendance = () => {
+  const navigate = useNavigate();
+  const [updateCurrentAttendance, org] = useGlobalStore((state) => [
+    state.updateCurrentAttendance,
+    state.organisation,
+  ]);
+  const { categories } = useCategories(org.id);
+  const [details, setDetails] = useState<AttendanceDetails>(EMPTY_DETAILS);
+
+  const onContinue = () => {
+    if (!details.name.trim() || !details.date) {
+      toast.error("Name and date are required");
+      return;
+    }
+    const payload: currentAttendanceType = {
+      name: details.name.trim(),
+      date: details.date,
+      ...(details.categoryId ? { categoryId: details.categoryId } : {}),
+      ...(details.subCategoryId ? { subCategoryId: details.subCategoryId } : {}),
+    };
+    updateCurrentAttendance(payload);
+    queryClient.invalidateQueries({ queryKey: [Q_KEY.GET_MEMBERS] });
+    navigate(PROTECTED_PATHS.MARK_ATTENANCE);
+  };
+
+  return (
+    <Box minH={"100vh"} bg={useColorModeValue("gray.50", "gray.800")}>
+      <Flex
+        bg="blue.500"
+        justifyContent="space-between"
+        alignItems="center"
+        p="4"
+      >
+        <Text fontWeight="bold" color="#fff">
+          Create Attendance
+        </Text>
+      </Flex>
+      <Button
+        variant="logout"
+        colorScheme="blue"
+        onClick={() => navigate(PROTECTED_PATHS.DASHBOARD)}
+        mr={2}
+        leftIcon={<FaArrowCircleLeft />}
+        m="2"
+      >
+        Back
+      </Button>
+      <Flex>
+        <Button mt="4" ml="2" onClick={() => navigate(PROTECTED_PATHS.CATEGORY)}>
+          Add Category
+        </Button>
+        <Button
+          mt="4"
+          ml="6"
+          onClick={() => navigate(PROTECTED_PATHS.SUB_CATEGORY)}
+        >
+          Add Sub-Category
+        </Button>
+      </Flex>
+      <Flex
+        align={"center"}
+        justify={"center"}
+        bg={useColorModeValue("gray.50", "gray.800")}
+      >
+        <Stack
+          spacing={4}
+          w={"full"}
+          mt="5rem"
+          maxW={"md"}
+          bg={useColorModeValue("white", "gray.700")}
+          rounded={"xl"}
+          boxShadow={"lg"}
+          p={6}
+        >
+          <AttendanceDetailsForm
+            value={details}
+            onChange={setDetails}
+            categories={categories}
+          />
+          <Button
+            w="full"
+            mt="40px"
+            bg={"blue.400"}
+            color={"white"}
+            _hover={{ bg: "blue.500" }}
+            fontWeight="bold"
+            fontSize="15px"
+            onClick={onContinue}
+          >
+            Continue
+          </Button>
+        </Stack>
+      </Flex>
+    </Box>
+  );
+};
+
+export default CreateAttendance;
+```
+
+- [ ] **Step 2: Typecheck and run the full suite**
+
+Run: `npx tsc --noEmit`
+Expected: no errors. (Note: `CreateAttendance` no longer exports `CategoryType`; Task 1 already repointed `SubCategory`'s import, so this compiles.)
+Run: `CI=true yarn test --watchAll=false`
+Expected: all PASS.
+
+- [ ] **Step 3: Manual verification**
+
+`yarn start`; Dashboard → Create Attendance. Confirm the form still has Name/Category/Sub Category/Date, sub-category options track the chosen category, blank name/date shows the "Name and date are required" toast, and Continue lands on the member roster with the chosen values.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/CreateAttendance.tsx
+git commit -m "refactor: build CreateAttendance from shared details form + useCategories"
+```
+
+---
+
+### Task 4: Surface editable details on `MarkAttendance` (edit mode)
+
+**Files:**
+- Modify: `src/pages/MarkAttendance.tsx` (imports; derive details; render form in update mode; guard Update)
+
+**Interfaces:**
+- Consumes: `useCategories` (Task 1), `AttendanceDetailsForm` + `AttendanceDetails` (Task 2). Relies on `currentAttendance.date` being `string` (Task 1).
+
+- [ ] **Step 1: Add imports**
+
+In `src/pages/MarkAttendance.tsx`, after the `LoadingSpinner` import (line 34), add:
+
+```ts
+import { useCategories } from "hooks/useCategories";
+import AttendanceDetailsForm, {
+  AttendanceDetails,
+} from "components/attendance/AttendanceDetailsForm";
+```
+
+- [ ] **Step 2: Fetch categories and derive the details value + change handler**
+
+In the `MarkAttendance` component body, immediately after the line `const localStorageKey = \`attendance-${org.id}\`;` (line 109), add:
+
+```ts
+  const { categories } = useCategories(org.id);
+  const detailsCardBg = useColorModeValue("white", "gray.700");
+
+  // Edit mode shows the session-details form, driven by the loaded currentAttendance.
+  const details: AttendanceDetails = {
+    name: currentAttendance.name ?? "",
+    categoryId: currentAttendance.categoryId ?? "",
+    subCategoryId: currentAttendance.subCategoryId ?? "",
+    date: (currentAttendance.date ?? "").slice(0, 10),
+  };
+
+  const onDetailsChange = (next: AttendanceDetails) => {
+    setAttendance({
+      ...currentAttendance,
+      name: next.name,
+      date: next.date,
+      categoryId: next.categoryId || undefined,
+      subCategoryId: next.subCategoryId || undefined,
+    });
+  };
+```
+
+- [ ] **Step 3: Render the form above the roster in update mode**
+
+In the JSX, inside the `!isLoadingData` branch, immediately after the opening `<>` (currently line 309) and before the search `InputGroup` (line 310), add:
+
+```tsx
+            {isUpdate && (
+              <Box
+                mt="4"
+                p="4"
+                bg={detailsCardBg}
+                rounded="xl"
+                boxShadow="sm"
+              >
+                <AttendanceDetailsForm
+                  value={details}
+                  onChange={onDetailsChange}
+                  categories={categories}
+                />
+              </Box>
+            )}
+```
+
+- [ ] **Step 4: Guard the Update button on name + date**
+
+Replace the submit button's `isDisabled` prop (currently `isDisabled={attendanceInfo.present === 0}`, line 360) with:
+
+```tsx
+              isDisabled={
+                attendanceInfo.present === 0 ||
+                (isUpdate && (!details.name.trim() || !details.date))
+              }
+```
+
+- [ ] **Step 5: Typecheck and run the full suite**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+Run: `CI=true yarn test --watchAll=false`
+Expected: all PASS.
+
+- [ ] **Step 6: Manual verification (edit round-trip)**
+
+`yarn start`; open an editable session (one with edits remaining) via the pencil on All Attendance. Confirm the details form appears prefilled with the session's name/category/sub-category/date; change the name, pick a different category (sub-category resets), change the date; toggle a member; Update. Reload the session and confirm the new name/category/date persisted. Confirm clearing the name disables Update.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pages/MarkAttendance.tsx
+git commit -m "feat: allow editing name/category/sub-category/date on attendance edit"
+```
+
+---
+
+### Task 5: Render the org logo image
+
+**Files:**
+- Modify: `src/pages/Organisations.tsx:112` (avatar `src`)
+- Modify: `src/pages/OrganisationSettings.tsx` (Chakra import; `watch`; logo preview)
+
+**Interfaces:**
+- Consumes: `org.image` (already on `OrganisationType`).
+
+- [ ] **Step 1: Give the org-list avatar an image source**
+
+In `src/pages/Organisations.tsx`, change the avatar (line 112) from:
+
+```tsx
+                  <Avatar name={org.name} w="45px" h="45px" />
+```
+
+to:
+
+```tsx
+                  <Avatar name={org.name} src={org.image} w="45px" h="45px" />
+```
+
+(Chakra `Avatar` falls back to name-initials automatically when `src` is empty or fails to load.)
+
+- [ ] **Step 2: Add a logo preview on the settings page**
+
+In `src/pages/OrganisationSettings.tsx`:
+
+Add `Avatar` to the Chakra import (it currently imports `Box, Flex, Text, Button, Stack, FormControl, FormLabel, FormErrorMessage, FormHelperText, Input, Switch, useColorModeValue`) — add `Avatar`:
+
+```ts
+import {
+  Box,
+  Flex,
+  Text,
+  Button,
+  Stack,
+  FormControl,
+  FormLabel,
+  FormErrorMessage,
+  FormHelperText,
+  Input,
+  Switch,
+  Avatar,
+  useColorModeValue,
+} from "@chakra-ui/react";
+```
+
+Add `watch` to the `useForm` destructure (currently `const { register, handleSubmit, reset, formState: { errors } } = useForm<OrgSettingsForm>({...})`):
+
+```ts
+  const {
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { errors },
+  } = useForm<OrgSettingsForm>({
+```
+
+Replace the Logo URL `FormControl` block (currently the `<Input>` for `image` wrapped in its `FormControl`) so the input sits beside a live preview:
+
+```tsx
+                <FormControl isInvalid={Boolean(errors.image)}>
+                  <FormLabel>Logo URL</FormLabel>
+                  <Flex align="center" gap={3}>
+                    <Avatar
+                      name={watch("name")}
+                      src={watch("image")}
+                      size="md"
+                    />
+                    <Input
+                      placeholder="https://cdn.example.com/logo.png"
+                      {...register("image", {
+                        validate: (v) =>
+                          v.trim() === "" ||
+                          isUrl(v.trim()) ||
+                          "Enter a valid URL",
+                      })}
+                    />
+                  </Flex>
+                  <FormErrorMessage>{errors.image?.message}</FormErrorMessage>
+                </FormControl>
+```
+
+- [ ] **Step 3: Typecheck and run the full suite**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+Run: `CI=true yarn test --watchAll=false`
+Expected: all PASS — in particular `src/pages/OrganisationSettings.test.tsx` still finds the "Logo URL" field by label (the `FormControl` still assigns its id to the `Input`; the `Avatar` is not a form control).
+
+- [ ] **Step 4: Manual verification**
+
+`yarn start`; open Organisation Settings, paste a valid image URL → the preview avatar updates live. Save, go to the org switcher (`/organisations`) → the org now shows the logo (a broken/empty URL falls back to initials). 
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/Organisations.tsx src/pages/OrganisationSettings.tsx
+git commit -m "feat: display org logo on org list and settings preview"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `useCategories` hook (dedup fetch) → Task 1. Shared types moved + `SubCategory` repointed → Task 1.
+- `AttendanceDetailsForm` presentational/controlled, sub-category filtered + reset on category change → Task 2.
+- `CreateAttendance` reuses hook + component, behavior preserved → Task 3.
+- `MarkAttendance` edit-mode form, seeded from `currentAttendance`, writes back, Update guarded on name/date → Task 4.
+- Org image: avatar `src` + settings preview → Task 5.
+- Date-as-string correctness (spec: dates are `"YYYY-MM-DD"`) → Task 1 fixes `currentAttendanceType.date`, removing casts in Tasks 3/4.
+- Testing: `useCategories` (Task 1), `AttendanceDetailsForm` (Task 2); Create/Mark verified by tsc + suite + manual round-trips (Tasks 3/4); settings-label regression re-checked (Task 5).
+
+**Placeholder scan:** none — every code step carries full code.
+
+**Type consistency:** `AttendanceDetails` (Task 2) used verbatim in Tasks 3/4. `CategoryType`/`useCategories` (Task 1) used in Tasks 2/3/4. `currentAttendanceType.date: string` (Task 1) is what Tasks 3/4 assign without casts. `onChange(next: AttendanceDetails)` signature matches `setDetails` (Task 3) and `onDetailsChange` (Task 4).
+
+**Cross-task note:** Task 1 repoints `SubCategory`'s `CategoryType` import BEFORE Task 3 removes the export from `CreateAttendance`, so there is no window where the import dangles. If executed out of order, run Task 1 before Task 3.

--- a/docs/superpowers/specs/2026-07-14-editable-attendance-details-and-org-image-design.md
+++ b/docs/superpowers/specs/2026-07-14-editable-attendance-details-and-org-image-design.md
@@ -1,0 +1,132 @@
+# Editable Attendance Session Details + Org Image Display — Design
+
+**Date:** 2026-07-14
+**Status:** Approved (pending spec review)
+
+## Goal
+
+Two follow-ups surfaced while testing the org-settings / attendance-edit work:
+
+1. **Editable session details on attendance edit.** The attendance edit screen only
+   lets you re-toggle member present/apology status. Users need to also edit the
+   session's **name, category, sub-category, and date** — the values are already
+   loaded and re-sent on update, but there are no controls to change them.
+2. **Org image never displays.** A logo URL saved via Organisation Settings round-trips
+   to the backend but is not rendered anywhere — the org avatar is drawn from the org
+   name only.
+
+## Context / current state
+
+- **Attendance edit** lives in `src/pages/MarkAttendance.tsx` (create + update in one
+  component; update detected by `params.attendanceId`). In update mode
+  `onGetAttandanceSuccess` (`:151-172`) loads `name/date/categoryId/subCategoryId` into
+  the `currentAttendance` store and builds the roster; the submit path
+  (`sendAttandanceToAPI`, `:234-259`) spreads `...currentAttendance` plus
+  `presentMembers`/`apologisedMembers` into the `PUT`. The UI renders only the member
+  roster + status toggles — no inputs for name/category/date.
+- **The create flow** collects those fields on a separate earlier screen
+  `src/pages/CreateAttendance.tsx` (react-hook-form: name `Input`, category `Select`,
+  sub-category `Select` filtered by selected category, date `Input type="date"` capped
+  at today), writes `currentAttendance`, then navigates to `MarkAttendance`.
+  `CreateAttendance` owns the category query (`useQueryWrapper(["get-all-category"], …)`)
+  and the `CategoryType`/`SubCategoryType` types (`:26-36`).
+- **`PUT /attendance/:id`** already accepts `name/date/categoryId/subCategoryId`;
+  **`GET /attendance/:organisationId/:id`** returns those IDs (already picked into the
+  store). No endpoint changes needed.
+- **Org avatar** in `src/pages/Organisations.tsx:112` is `<Avatar name={org.name} … />`
+  — no `src`, so it always shows name-initials. `AppHeader.tsx:61` is the *user* avatar.
+  The store `OrganisationType` carries `image` and the settings save merges it in, so the
+  value is present client-side; nothing consumes it.
+- Stack (unchanged): React 18 + TS strict, Chakra UI v2, Zustand (persisted), React
+  Query v4, react-hook-form v7, react-toastify. No i18n layer. Tests: Jest +
+  @testing-library/react via `react-scripts test`.
+
+## Decision (from brainstorming)
+
+**Inline editable details on the edit screen, via one shared form component** — extract
+the session-details fields into a reusable presentational component used by BOTH the
+create screen and the edit screen (single-screen edit, DRY, one source of truth for the
+form). (Rejected: duplicating the fields inline; and a two-step edit that reuses the
+create screen.)
+
+## Design
+
+### Unit 1 — `useCategories(organisationId)` hook
+
+New `src/hooks/useCategories.ts`. Wraps the org category query (the one currently inline
+in `CreateAttendance`), returning `{ categories: CategoryType[]; isLoading: boolean }`.
+Move the shared `CategoryType`/`SubCategoryType` types into this module (or a sibling
+`attendance` types file) and re-export; `CreateAttendance` imports them from there
+instead of declaring its own. One fetch definition, used by both screens.
+
+### Unit 2 — `AttendanceDetailsForm` (presentational, controlled)
+
+New `src/components/attendance/AttendanceDetailsForm.tsx`.
+
+- Type: `interface AttendanceDetails { name: string; categoryId: string; subCategoryId: string; date: string; }` (`date` = `"YYYY-MM-DD"`).
+- Props: `{ value: AttendanceDetails; onChange: (next: AttendanceDetails) => void; categories: CategoryType[]; }`.
+- Renders: name `Input`; category `Select`; sub-category `Select` whose options are the
+  selected category's `subCategories` (empty when no category chosen); date
+  `Input type="date"` with `max` = today.
+- Behavior: fully controlled — every field edit calls `onChange` with the next value.
+  When the category changes, `subCategoryId` is reset to `""` (stale sub-category can't
+  survive a category switch). No internal persistence, no data fetching, no submit
+  button — the parent owns all of that.
+
+### `CreateAttendance` — consume the shared component
+
+Replace the inline `FormControl` fields with `<AttendanceDetailsForm>`. Hold the four
+values in local `useState<AttendanceDetails>` (seeded empty). Fetch categories via
+`useCategories`. On **Continue**: validate `name` and `date` are non-empty (toast on
+failure), write the trimmed values to `currentAttendance`, invalidate `GET_MEMBERS`,
+navigate to `MARK_ATTENANCE`. Net behavior identical to today; only the form markup and
+the category fetch are now shared.
+
+### `MarkAttendance` — surface the form in edit mode
+
+When `isUpdate`, render `<AttendanceDetailsForm>` above the roster, seeded from the
+loaded `currentAttendance` (map the API `date` to `"YYYY-MM-DD"`; coerce missing
+category/sub-category to `""`). Fetch categories via `useCategories`. `onChange` writes
+back with `setAttendance({ ...currentAttendance, ...next })`. The existing submit path
+already spreads `...currentAttendance`, so edited details ride along on the `PUT`.
+Disable the **Update** button when `name` or `date` is empty (in addition to the
+existing present-count guard). Create mode is unchanged — no details form there.
+
+### Bug #1 — org image display
+
+- `src/pages/Organisations.tsx:112`: `<Avatar name={org.name} src={org.image} … />`.
+  Chakra falls back to name-initials automatically when `src` is empty or fails to load.
+- `src/pages/OrganisationSettings.tsx`: render a small logo preview (an `Avatar`/`Image`
+  bound to the current image field value) beside the Logo URL input so the user can see
+  what they entered.
+
+## Data flow / contract
+
+No new endpoints. Edit: `GET .../:id` → IDs into `currentAttendance` → prefill form →
+edits update `currentAttendance` → `PUT /attendance/:id` with
+`name/date/categoryId/subCategoryId` + member arrays. Errors surface through the existing
+`MarkAttendance` `onError` toast (which also carries the edit-limit 400 and any BE
+validation 422).
+
+## Error handling
+
+- Client-side: block Update when name/date empty; keep the present-count guard.
+- Server-side: existing toast path renders `error.response.data.error` for 400/422.
+
+## Testing
+
+- Unit-test `AttendanceDetailsForm`: renders all four fields; sub-category options are
+  those of the selected category; changing the category clears `subCategoryId`;
+  `onChange` fires with the patched value.
+- Unit-test `useCategories`: returns the fetched list on success (light test, mockable).
+- `CreateAttendance` and `MarkAttendance` verified by `npx tsc --noEmit` + full suite +
+  a manual edit round-trip: open an editable session, change name + category + date,
+  Update, confirm persisted values on reload; confirm sub-category clears on category
+  change; confirm a saved org logo now shows in the org list and the settings preview.
+
+## Out of scope (YAGNI)
+
+- No time-of-day / date-range fields; no category CRUD changes.
+- No image upload — URL string only.
+- Create flow keeps its current two-screen shape (details screen → roster screen).
+- No i18n — strings hardcoded, matching the codebase.

--- a/src/components/attendance/AttendanceDetailsForm.test.tsx
+++ b/src/components/attendance/AttendanceDetailsForm.test.tsx
@@ -14,7 +14,14 @@ const categories: CategoryType[] = [
       { id: "s2", name: "Second Mass", status: "active", parentCategoryId: "c1" },
     ],
   },
-  { id: "c2", name: "Weekday", status: "active", subCategories: [] },
+  {
+    id: "c2",
+    name: "Weekday",
+    status: "active",
+    subCategories: [
+      { id: "s3", name: "Weekday Mass", status: "active", parentCategoryId: "c2" },
+    ],
+  },
 ];
 
 const base: AttendanceDetails = { name: "", categoryId: "", subCategoryId: "", date: "" };
@@ -39,6 +46,20 @@ it("shows sub-categories of the selected category", () => {
   );
   expect(screen.getByRole("option", { name: "First Mass" })).toBeInTheDocument();
   expect(screen.getByRole("option", { name: "Second Mass" })).toBeInTheDocument();
+  // Only the selected category's sub-categories show — not another category's.
+  expect(
+    screen.queryByRole("option", { name: "Weekday Mass" }),
+  ).not.toBeInTheDocument();
+});
+
+it("shows no sub-category options when no category is selected", () => {
+  render(<AttendanceDetailsForm value={base} onChange={() => {}} categories={categories} />);
+  expect(
+    screen.queryByRole("option", { name: "First Mass" }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("option", { name: "Weekday Mass" }),
+  ).not.toBeInTheDocument();
 });
 
 it("clears the sub-category when the category changes", () => {

--- a/src/components/attendance/AttendanceDetailsForm.test.tsx
+++ b/src/components/attendance/AttendanceDetailsForm.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import AttendanceDetailsForm, {
+  AttendanceDetails,
+} from "components/attendance/AttendanceDetailsForm";
+import { CategoryType } from "hooks/useCategories";
+
+const categories: CategoryType[] = [
+  {
+    id: "c1",
+    name: "Sunday Service",
+    status: "active",
+    subCategories: [
+      { id: "s1", name: "First Mass", status: "active", parentCategoryId: "c1" },
+      { id: "s2", name: "Second Mass", status: "active", parentCategoryId: "c1" },
+    ],
+  },
+  { id: "c2", name: "Weekday", status: "active", subCategories: [] },
+];
+
+const base: AttendanceDetails = { name: "", categoryId: "", subCategoryId: "", date: "" };
+
+it("renders all four fields", () => {
+  render(<AttendanceDetailsForm value={base} onChange={() => {}} categories={categories} />);
+  expect(screen.getByLabelText("Name")).toBeInTheDocument();
+  expect(screen.getByLabelText("Category")).toBeInTheDocument();
+  expect(screen.getByLabelText("Sub Category")).toBeInTheDocument();
+  expect(screen.getByLabelText("Date")).toBeInTheDocument();
+});
+
+it("shows sub-categories of the selected category", () => {
+  render(
+    <AttendanceDetailsForm
+      value={{ ...base, categoryId: "c1" }}
+      onChange={() => {}}
+      categories={categories}
+    />,
+  );
+  expect(screen.getByRole("option", { name: "First Mass" })).toBeInTheDocument();
+  expect(screen.getByRole("option", { name: "Second Mass" })).toBeInTheDocument();
+});
+
+it("clears the sub-category when the category changes", () => {
+  const onChange = jest.fn();
+  render(
+    <AttendanceDetailsForm
+      value={{ ...base, categoryId: "c1", subCategoryId: "s1" }}
+      onChange={onChange}
+      categories={categories}
+    />,
+  );
+  fireEvent.change(screen.getByLabelText("Category"), { target: { value: "c2" } });
+  expect(onChange).toHaveBeenCalledWith(
+    expect.objectContaining({ categoryId: "c2", subCategoryId: "" }),
+  );
+});
+
+it("emits name edits", () => {
+  const onChange = jest.fn();
+  render(<AttendanceDetailsForm value={base} onChange={onChange} categories={categories} />);
+  fireEvent.change(screen.getByLabelText("Name"), { target: { value: "First Mass" } });
+  expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ name: "First Mass" }));
+});

--- a/src/components/attendance/AttendanceDetailsForm.test.tsx
+++ b/src/components/attendance/AttendanceDetailsForm.test.tsx
@@ -21,10 +21,12 @@ const base: AttendanceDetails = { name: "", categoryId: "", subCategoryId: "", d
 
 it("renders all four fields", () => {
   render(<AttendanceDetailsForm value={base} onChange={() => {}} categories={categories} />);
-  expect(screen.getByLabelText("Name")).toBeInTheDocument();
+  // Name and Date are required, so Chakra appends a "*" indicator to the
+  // accessible label — match with a regex rather than the exact string.
+  expect(screen.getByLabelText(/Name/)).toBeInTheDocument();
   expect(screen.getByLabelText("Category")).toBeInTheDocument();
   expect(screen.getByLabelText("Sub Category")).toBeInTheDocument();
-  expect(screen.getByLabelText("Date")).toBeInTheDocument();
+  expect(screen.getByLabelText(/Date/)).toBeInTheDocument();
 });
 
 it("shows sub-categories of the selected category", () => {
@@ -57,6 +59,6 @@ it("clears the sub-category when the category changes", () => {
 it("emits name edits", () => {
   const onChange = jest.fn();
   render(<AttendanceDetailsForm value={base} onChange={onChange} categories={categories} />);
-  fireEvent.change(screen.getByLabelText("Name"), { target: { value: "First Mass" } });
+  fireEvent.change(screen.getByLabelText(/Name/), { target: { value: "First Mass" } });
   expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ name: "First Mass" }));
 });

--- a/src/components/attendance/AttendanceDetailsForm.tsx
+++ b/src/components/attendance/AttendanceDetailsForm.tsx
@@ -1,0 +1,85 @@
+import { FormControl, FormLabel, Input, Select, Stack } from "@chakra-ui/react";
+import { CategoryType } from "hooks/useCategories";
+
+export interface AttendanceDetails {
+  name: string;
+  categoryId: string;
+  subCategoryId: string;
+  date: string; // YYYY-MM-DD
+}
+
+interface AttendanceDetailsFormProps {
+  value: AttendanceDetails;
+  onChange: (next: AttendanceDetails) => void;
+  categories: CategoryType[];
+}
+
+const AttendanceDetailsForm = ({
+  value,
+  onChange,
+  categories,
+}: AttendanceDetailsFormProps) => {
+  const subCategories =
+    categories.find((c) => c.id === value.categoryId)?.subCategories ?? [];
+  const today = new Date().toISOString().slice(0, 10);
+
+  return (
+    <Stack spacing={4}>
+      <FormControl id="name" isRequired>
+        <FormLabel mb="0">Name</FormLabel>
+        <Input
+          type="text"
+          placeholder="Attendance Name"
+          value={value.name}
+          onChange={(e) => onChange({ ...value, name: e.target.value })}
+        />
+      </FormControl>
+
+      <FormControl id="category">
+        <FormLabel mb="0">Category</FormLabel>
+        <Select
+          placeholder="Select option"
+          value={value.categoryId}
+          onChange={(e) =>
+            // Changing the category invalidates any previously chosen sub-category.
+            onChange({ ...value, categoryId: e.target.value, subCategoryId: "" })
+          }
+        >
+          {categories.map((category) => (
+            <option key={category.id} value={category.id}>
+              {category.name}
+            </option>
+          ))}
+        </Select>
+      </FormControl>
+
+      <FormControl id="subCategory">
+        <FormLabel mb="0">Sub Category</FormLabel>
+        <Select
+          placeholder="Select option"
+          value={value.subCategoryId}
+          isDisabled={subCategories.length === 0}
+          onChange={(e) => onChange({ ...value, subCategoryId: e.target.value })}
+        >
+          {subCategories.map((sub) => (
+            <option key={sub.id} value={sub.id}>
+              {sub.name}
+            </option>
+          ))}
+        </Select>
+      </FormControl>
+
+      <FormControl id="date" isRequired>
+        <FormLabel mb="0">Date</FormLabel>
+        <Input
+          type="date"
+          max={today}
+          value={value.date}
+          onChange={(e) => onChange({ ...value, date: e.target.value })}
+        />
+      </FormControl>
+    </Stack>
+  );
+};
+
+export default AttendanceDetailsForm;

--- a/src/components/attendance/AttendanceDetailsForm.tsx
+++ b/src/components/attendance/AttendanceDetailsForm.tsx
@@ -21,7 +21,13 @@ const AttendanceDetailsForm = ({
 }: AttendanceDetailsFormProps) => {
   const subCategories =
     categories.find((c) => c.id === value.categoryId)?.subCategories ?? [];
-  const today = new Date().toISOString().slice(0, 10);
+  // Cap at the user's LOCAL calendar day. toISOString() would use the UTC day,
+  // which is already "tomorrow" for evening users in timezones behind UTC.
+  const now = new Date();
+  const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(
+    2,
+    "0",
+  )}-${String(now.getDate()).padStart(2, "0")}`;
 
   return (
     <Stack spacing={4}>

--- a/src/hooks/useCategories.test.tsx
+++ b/src/hooks/useCategories.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { queryClient } from "services/api/apiHelper";
+import { useCategories } from "hooks/useCategories";
+
+jest.mock("services/api", () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(() =>
+      Promise.resolve({
+        data: {
+          data: [
+            { id: "c1", name: "Sunday Service", status: "active", subCategories: [] },
+          ],
+        },
+      }),
+    ),
+  },
+}));
+
+function Probe({ orgId }: { orgId: string }) {
+  const { categories } = useCategories(orgId);
+  return <div>count:{categories.length}</div>;
+}
+
+it("returns the fetched categories", async () => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <Probe orgId="org1" />
+    </QueryClientProvider>,
+  );
+  expect(await screen.findByText("count:1")).toBeInTheDocument();
+});

--- a/src/hooks/useCategories.test.tsx
+++ b/src/hooks/useCategories.test.tsx
@@ -3,31 +3,32 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "services/api/apiHelper";
 import { useCategories } from "hooks/useCategories";
 
-jest.mock("services/api", () => ({
-  __esModule: true,
-  default: {
-    get: jest.fn(() =>
-      Promise.resolve({
-        data: {
-          data: [
-            { id: "c1", name: "Sunday Service", status: "active", subCategories: [] },
-          ],
-        },
-      }),
-    ),
-  },
-}));
-
 function Probe({ orgId }: { orgId: string }) {
   const { categories } = useCategories(orgId);
   return <div>count:{categories.length}</div>;
 }
 
-it("returns the fetched categories", async () => {
+const renderProbe = (orgId: string) =>
   render(
     <QueryClientProvider client={queryClient}>
-      <Probe orgId="org1" />
+      <Probe orgId={orgId} />
     </QueryClientProvider>,
   );
-  expect(await screen.findByText("count:1")).toBeInTheDocument();
+
+it("derives the category list from the cached query payload", () => {
+  // The API wraps payloads as { data: ... }; the hook should read data.data.
+  queryClient.setQueryData(["get-all-category"], {
+    data: [
+      { id: "c1", name: "Sunday Service", status: "active", subCategories: [] },
+    ],
+  });
+  renderProbe("org1");
+  expect(screen.getByText("count:1")).toBeInTheDocument();
+});
+
+it("returns an empty list before any data has loaded", () => {
+  queryClient.removeQueries({ queryKey: ["get-all-category"] });
+  // orgId "" keeps the query disabled, so no data is ever present.
+  renderProbe("");
+  expect(screen.getByText("count:0")).toBeInTheDocument();
 });

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import { useQueryWrapper } from "services/api/apiHelper";
+import { convertParamsToString } from "helpers/stringManipulations";
+import { orgRequest } from "services/api/request";
+
+export interface CommonTypeCategory {
+  name: string;
+  status: string;
+  id: string;
+}
+
+export interface SubCategoryType extends CommonTypeCategory {
+  parentCategoryId: string;
+}
+
+export interface CategoryType extends CommonTypeCategory {
+  subCategories: SubCategoryType[];
+}
+
+/**
+ * Fetches the org's categories (with nested sub-categories). Shared by the
+ * create and edit attendance screens. Uses the existing "get-all-category"
+ * query key so React Query dedupes across screens.
+ */
+export const useCategories = (organisationId: string) => {
+  const [categories, setCategories] = useState<CategoryType[]>([]);
+  const url = convertParamsToString(orgRequest.CATEGORY, { organisationId });
+  const { isLoading } = useQueryWrapper(["get-all-category"], url, {
+    enabled: Boolean(organisationId),
+    onSuccess: (res: { data: CategoryType[] }) => setCategories(res.data),
+  });
+  return { categories, isLoading };
+};

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useQueryWrapper } from "services/api/apiHelper";
 import { convertParamsToString } from "helpers/stringManipulations";
 import { orgRequest } from "services/api/request";
@@ -23,11 +22,12 @@ export interface CategoryType extends CommonTypeCategory {
  * query key so React Query dedupes across screens.
  */
 export const useCategories = (organisationId: string) => {
-  const [categories, setCategories] = useState<CategoryType[]>([]);
   const url = convertParamsToString(orgRequest.CATEGORY, { organisationId });
-  const { isLoading } = useQueryWrapper(["get-all-category"], url, {
+  const { data, isLoading } = useQueryWrapper(["get-all-category"], url, {
     enabled: Boolean(organisationId),
-    onSuccess: (res: { data: CategoryType[] }) => setCategories(res.data),
   });
+  // The API wraps payloads as { data: ... }; derive the list straight from the
+  // query cache rather than mirroring it into local state via onSuccess.
+  const categories: CategoryType[] = data?.data ?? [];
   return { categories, isLoading };
 };

--- a/src/pages/CreateAttendance.tsx
+++ b/src/pages/CreateAttendance.tsx
@@ -4,71 +4,52 @@ import {
   useColorModeValue,
   Text,
   Button,
-  FormControl,
-  FormLabel,
-  Input,
   Stack,
-  Select,
 } from "@chakra-ui/react";
-
 import { useNavigate } from "react-router-dom";
 import { PROTECTED_PATHS } from "routes/pagePath";
-import { useForm, SubmitHandler } from "react-hook-form";
 import useGlobalStore, { currentAttendanceType } from "zStore";
-import _ from "lodash";
-import { queryClient, useQueryWrapper } from "services/api/apiHelper";
-import { convertParamsToString } from "helpers/stringManipulations";
-import { orgRequest } from "services";
-import { useState } from "react";
+import { queryClient } from "services/api/apiHelper";
 import { Q_KEY } from "utils/constant";
 import { FaArrowCircleLeft } from "react-icons/fa";
+import { useState } from "react";
+import { toast } from "react-toastify";
+import { useCategories } from "hooks/useCategories";
+import AttendanceDetailsForm, {
+  AttendanceDetails,
+} from "components/attendance/AttendanceDetailsForm";
 
-type CommonTypeCategory = {
-  name: string;
-  status: string;
-  id: string;
+const EMPTY_DETAILS: AttendanceDetails = {
+  name: "",
+  categoryId: "",
+  subCategoryId: "",
+  date: "",
 };
-interface SubCategoryType extends CommonTypeCategory {
-  parentCategoryId: string;
-}
-export interface CategoryType extends CommonTypeCategory {
-  subCategories: SubCategoryType[];
-}
 
 const CreateAttendance = () => {
-  const { register, handleSubmit, watch } = useForm<currentAttendanceType>();
-  const categorySelected = watch(["categoryId"]);
+  const navigate = useNavigate();
   const [updateCurrentAttendance, org] = useGlobalStore((state) => [
     state.updateCurrentAttendance,
     state.organisation,
   ]);
-  const onSubmit: SubmitHandler<currentAttendanceType> = (formData) => {
-    const trimmedFormData = _.mapValues(formData, (value) => {
-      if (typeof value === "string") {
-        return value.trim();
-      }
-      return value;
-    });
+  const { categories } = useCategories(org.id);
+  const [details, setDetails] = useState<AttendanceDetails>(EMPTY_DETAILS);
 
-    const nonEmptyFormData = _.omitBy(trimmedFormData, _.isEmpty);
-    updateCurrentAttendance(nonEmptyFormData as currentAttendanceType);
+  const onContinue = () => {
+    if (!details.name.trim() || !details.date) {
+      toast.error("Name and date are required");
+      return;
+    }
+    const payload: currentAttendanceType = {
+      name: details.name.trim(),
+      date: details.date,
+      ...(details.categoryId ? { categoryId: details.categoryId } : {}),
+      ...(details.subCategoryId ? { subCategoryId: details.subCategoryId } : {}),
+    };
+    updateCurrentAttendance(payload);
     queryClient.invalidateQueries({ queryKey: [Q_KEY.GET_MEMBERS] });
-
     navigate(PROTECTED_PATHS.MARK_ATTENANCE);
-    // Q_KEY.GET_MEMBERS
   };
-  const catUrl = convertParamsToString(orgRequest.CATEGORY, {
-    organisationId: org.id,
-  });
-  const [allCategory, setAllCategory] = useState<CategoryType[]>([]);
-  const onSuccess = (res) => {
-    setAllCategory(res.data);
-  };
-  useQueryWrapper(["get-all-category"], catUrl, {
-    onSuccess,
-  });
-
-  const navigate = useNavigate();
 
   return (
     <Box minH={"100vh"} bg={useColorModeValue("gray.50", "gray.800")}>
@@ -93,11 +74,7 @@ const CreateAttendance = () => {
         Back
       </Button>
       <Flex>
-        <Button
-          mt="4"
-          ml="2"
-          onClick={() => navigate(PROTECTED_PATHS.CATEGORY)}
-        >
+        <Button mt="4" ml="2" onClick={() => navigate(PROTECTED_PATHS.CATEGORY)}>
           Add Category
         </Button>
         <Button
@@ -123,69 +100,23 @@ const CreateAttendance = () => {
           boxShadow={"lg"}
           p={6}
         >
-          <form onSubmit={handleSubmit(onSubmit)}>
-            <FormControl id="name" isRequired>
-              <FormLabel mb="0">Name</FormLabel>
-              <Input
-                type="text"
-                {...register("name", { required: true })}
-                placeholder="Attendance Name"
-              />
-            </FormControl>
-            <FormControl id="category" mt="4">
-              <FormLabel mb="0">Category</FormLabel>
-              <Select
-                placeholder="Select option"
-                {...register("categoryId", { required: false })}
-              >
-                {allCategory.map((category) => (
-                  <option key={category.id} value={category.id}>
-                    {category.name}
-                  </option>
-                ))}
-              </Select>
-            </FormControl>
-            <FormControl id="subCategory" mt="4">
-              <FormLabel mb="0">Sub Category</FormLabel>
-              <Select
-                placeholder="Select option"
-                {...register("subCategoryId", { required: false })}
-              >
-                {allCategory
-                  .find((category) => category.id === categorySelected[0])
-                  ?.subCategories.map((subCategory) => (
-                    <option key={subCategory.id} value={subCategory.id}>
-                      {subCategory.name}
-                    </option>
-                  ))}
-              </Select>
-            </FormControl>
-            <FormControl id="date" isRequired mt="4">
-              <FormLabel mb="0">Date</FormLabel>
-              <Input
-                type="date"
-                max={new Date().toISOString().slice(0, 10)}
-                {...register("date", { required: true })}
-              />
-            </FormControl>
-
-            <Box>
-              <Button
-                w="full"
-                mt="40px"
-                bg={"blue.400"}
-                color={"white"}
-                _hover={{
-                  bg: "blue.500",
-                }}
-                fontWeight="bold"
-                fontSize="15px"
-                type="submit"
-              >
-                Continue
-              </Button>
-            </Box>
-          </form>
+          <AttendanceDetailsForm
+            value={details}
+            onChange={setDetails}
+            categories={categories}
+          />
+          <Button
+            w="full"
+            mt="40px"
+            bg={"blue.400"}
+            color={"white"}
+            _hover={{ bg: "blue.500" }}
+            fontWeight="bold"
+            fontSize="15px"
+            onClick={onContinue}
+          >
+            Continue
+          </Button>
         </Stack>
       </Flex>
     </Box>

--- a/src/pages/MarkAttendance.tsx
+++ b/src/pages/MarkAttendance.tsx
@@ -324,36 +324,35 @@ const MarkAttendance = () => {
         </Text>
       </Flex>
       <Container>
-        <Flex alignItems="center" justifyContent="space-between" mt="4">
-          <Heading fontSize="22px">
+        <Flex alignItems="center" justifyContent="space-between" mt="4" gap={2}>
+          <Heading fontSize="22px" noOfLines={1}>
             {`Members ${currentAttendance.name}`}
           </Heading>
-          <Button
-            variant="logout"
-            onClick={() => {
-              localStorage.removeItem(localStorageKey);
-              window.location.reload();
-            }}
-          >
-            Refresh
-          </Button>
+          <Flex gap={2} alignItems="center" flexShrink={0}>
+            {isUpdate && (
+              <IconButton
+                aria-label="Edit session details"
+                icon={<FaPencilAlt />}
+                variant="outline"
+                colorScheme="blue"
+                onClick={detailsDrawer.onOpen}
+              />
+            )}
+            <Button
+              variant="logout"
+              onClick={() => {
+                localStorage.removeItem(localStorageKey);
+                window.location.reload();
+              }}
+            >
+              Refresh
+            </Button>
+          </Flex>
         </Flex>
         {isLoadingData ? (
           <LoadingSpinner h="45vh" text="Loading members..." />
         ) : (
           <>
-            {isUpdate && (
-              <Button
-                mt="4"
-                w="full"
-                variant="outline"
-                colorScheme="blue"
-                leftIcon={<FaPencilAlt />}
-                onClick={detailsDrawer.onOpen}
-              >
-                Edit session details
-              </Button>
-            )}
             <InputGroup mt="4">
               <InputLeftElement pointerEvents="none">
                 <Icon as={FaSearch} color="gray.400" />

--- a/src/pages/MarkAttendance.tsx
+++ b/src/pages/MarkAttendance.tsx
@@ -12,8 +12,16 @@ import {
   IconButton,
   Icon,
   Container,
+  Drawer,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerCloseButton,
+  DrawerHeader,
+  DrawerBody,
+  DrawerFooter,
+  useDisclosure,
 } from "@chakra-ui/react";
-import { FaSearch } from "react-icons/fa";
+import { FaSearch, FaPencilAlt } from "react-icons/fa";
 import { FiX } from "react-icons/fi";
 import { convertParamsToString } from "helpers/stringManipulations";
 import { memo, useCallback, useMemo, useRef, useState } from "react";
@@ -112,7 +120,7 @@ const MarkAttendance = () => {
   const isUpdate = params.attendanceId !== undefined;
   const localStorageKey = `attendance-${org.id}`;
   const { categories } = useCategories(org.id);
-  const detailsCardBg = useColorModeValue("white", "gray.700");
+  const detailsDrawer = useDisclosure();
 
   // Edit mode shows the session-details form, driven by the loaded currentAttendance.
   const details: AttendanceDetails = {
@@ -335,19 +343,16 @@ const MarkAttendance = () => {
         ) : (
           <>
             {isUpdate && (
-              <Box
+              <Button
                 mt="4"
-                p="4"
-                bg={detailsCardBg}
-                rounded="xl"
-                boxShadow="sm"
+                w="full"
+                variant="outline"
+                colorScheme="blue"
+                leftIcon={<FaPencilAlt />}
+                onClick={detailsDrawer.onOpen}
               >
-                <AttendanceDetailsForm
-                  value={details}
-                  onChange={onDetailsChange}
-                  categories={categories}
-                />
-              </Box>
+                Edit session details
+              </Button>
             )}
             <InputGroup mt="4">
               <InputLeftElement pointerEvents="none">
@@ -418,6 +423,33 @@ const MarkAttendance = () => {
           </>
         )}
       </Container>
+
+      {isUpdate && (
+        <Drawer
+          isOpen={detailsDrawer.isOpen}
+          placement="right"
+          onClose={detailsDrawer.onClose}
+          size={{ base: "full", md: "md" }}
+        >
+          <DrawerOverlay />
+          <DrawerContent>
+            <DrawerCloseButton />
+            <DrawerHeader>Session details</DrawerHeader>
+            <DrawerBody>
+              <AttendanceDetailsForm
+                value={details}
+                onChange={onDetailsChange}
+                categories={categories}
+              />
+            </DrawerBody>
+            <DrawerFooter>
+              <Button w="full" variant="primary" onClick={detailsDrawer.onClose}>
+                Done
+              </Button>
+            </DrawerFooter>
+          </DrawerContent>
+        </Drawer>
+      )}
     </Box>
   );
 };

--- a/src/pages/MarkAttendance.tsx
+++ b/src/pages/MarkAttendance.tsx
@@ -206,6 +206,9 @@ const MarkAttendance = () => {
     {
       onSuccess: onGetAttandanceSuccess,
       enabled: isUpdate,
+      // A refocus refetch would re-run onSuccess and overwrite the user's
+      // in-progress name/category/date/member edits with the server values.
+      refetchOnWindowFocus: false,
     }
   );
 

--- a/src/pages/MarkAttendance.tsx
+++ b/src/pages/MarkAttendance.tsx
@@ -32,6 +32,10 @@ import { Q_KEY } from "utils/constant";
 import _ from "lodash";
 import { toast } from "react-toastify";
 import LoadingSpinner from "components/LoadingSpinner";
+import { useCategories } from "hooks/useCategories";
+import AttendanceDetailsForm, {
+  AttendanceDetails,
+} from "components/attendance/AttendanceDetailsForm";
 
 export type AttendanceStatus = "absent" | "present" | "apology";
 
@@ -107,6 +111,26 @@ const MarkAttendance = () => {
   const params = useParams();
   const isUpdate = params.attendanceId !== undefined;
   const localStorageKey = `attendance-${org.id}`;
+  const { categories } = useCategories(org.id);
+  const detailsCardBg = useColorModeValue("white", "gray.700");
+
+  // Edit mode shows the session-details form, driven by the loaded currentAttendance.
+  const details: AttendanceDetails = {
+    name: currentAttendance.name ?? "",
+    categoryId: currentAttendance.categoryId ?? "",
+    subCategoryId: currentAttendance.subCategoryId ?? "",
+    date: (currentAttendance.date ?? "").slice(0, 10),
+  };
+
+  const onDetailsChange = (next: AttendanceDetails) => {
+    setAttendance({
+      ...currentAttendance,
+      name: next.name,
+      date: next.date,
+      categoryId: next.categoryId || undefined,
+      subCategoryId: next.subCategoryId || undefined,
+    });
+  };
 
   // filtered list + status counts are pure derivations of allMembers/searchQuery,
   // so we compute them here instead of storing (and hand-syncing) extra state.
@@ -307,6 +331,21 @@ const MarkAttendance = () => {
           <LoadingSpinner h="45vh" text="Loading members..." />
         ) : (
           <>
+            {isUpdate && (
+              <Box
+                mt="4"
+                p="4"
+                bg={detailsCardBg}
+                rounded="xl"
+                boxShadow="sm"
+              >
+                <AttendanceDetailsForm
+                  value={details}
+                  onChange={onDetailsChange}
+                  categories={categories}
+                />
+              </Box>
+            )}
             <InputGroup mt="4">
               <InputLeftElement pointerEvents="none">
                 <Icon as={FaSearch} color="gray.400" />
@@ -357,7 +396,10 @@ const MarkAttendance = () => {
               w="full"
               mt="8"
               isLoading={isLoading}
-              isDisabled={attendanceInfo.present === 0}
+              isDisabled={
+                attendanceInfo.present === 0 ||
+                (isUpdate && (!details.name.trim() || !details.date))
+              }
             >
               {isUpdate ? "Update" : "Submit"}
             </Button>

--- a/src/pages/MarkAttendance.tsx
+++ b/src/pages/MarkAttendance.tsx
@@ -127,8 +127,8 @@ const MarkAttendance = () => {
       ...currentAttendance,
       name: next.name,
       date: next.date,
-      categoryId: next.categoryId || undefined,
-      subCategoryId: next.subCategoryId || undefined,
+      categoryId: next.categoryId || null,
+      subCategoryId: next.subCategoryId || null,
     });
   };
 

--- a/src/pages/OrganisationSettings.tsx
+++ b/src/pages/OrganisationSettings.tsx
@@ -162,6 +162,7 @@ const OrganisationSettings = () => {
                       name={watch("name")}
                       src={watch("image")}
                       size="md"
+                      bg={watch("image") ? "white" : undefined}
                     />
                     <Input
                       placeholder="https://cdn.example.com/logo.png"

--- a/src/pages/OrganisationSettings.tsx
+++ b/src/pages/OrganisationSettings.tsx
@@ -163,6 +163,8 @@ const OrganisationSettings = () => {
                       src={watch("image")}
                       size="md"
                       bg={watch("image") ? "white" : undefined}
+                      borderWidth="2px"
+                      borderColor="blue.400"
                     />
                     <Input
                       placeholder="https://cdn.example.com/logo.png"

--- a/src/pages/OrganisationSettings.tsx
+++ b/src/pages/OrganisationSettings.tsx
@@ -10,6 +10,7 @@ import {
   FormHelperText,
   Input,
   Switch,
+  Avatar,
   useColorModeValue,
 } from "@chakra-ui/react";
 import { FaArrowCircleLeft } from "react-icons/fa";
@@ -56,6 +57,7 @@ const OrganisationSettings = () => {
     register,
     handleSubmit,
     reset,
+    watch,
     formState: { errors },
   } = useForm<OrgSettingsForm>({
     defaultValues: {
@@ -155,15 +157,22 @@ const OrganisationSettings = () => {
 
                 <FormControl isInvalid={Boolean(errors.image)}>
                   <FormLabel>Logo URL</FormLabel>
-                  <Input
-                    placeholder="https://cdn.example.com/logo.png"
-                    {...register("image", {
-                      validate: (v) =>
-                        v.trim() === "" ||
-                        isUrl(v.trim()) ||
-                        "Enter a valid URL",
-                    })}
-                  />
+                  <Flex align="center" gap={3}>
+                    <Avatar
+                      name={watch("name")}
+                      src={watch("image")}
+                      size="md"
+                    />
+                    <Input
+                      placeholder="https://cdn.example.com/logo.png"
+                      {...register("image", {
+                        validate: (v) =>
+                          v.trim() === "" ||
+                          isUrl(v.trim()) ||
+                          "Enter a valid URL",
+                      })}
+                    />
+                  </Flex>
                   <FormErrorMessage>{errors.image?.message}</FormErrorMessage>
                 </FormControl>
 

--- a/src/pages/Organisations.tsx
+++ b/src/pages/Organisations.tsx
@@ -109,7 +109,7 @@ const OrgList = () => {
                 }}
               >
                 <Flex alignItems="center">
-                  <Avatar name={org.name} w="45px" h="45px" />
+                  <Avatar name={org.name} src={org.image} w="45px" h="45px" />
                   <Text ml="4" textAlign="left">
                     {" "}
                     {org.name}

--- a/src/pages/Organisations.tsx
+++ b/src/pages/Organisations.tsx
@@ -109,7 +109,15 @@ const OrgList = () => {
                 }}
               >
                 <Flex alignItems="center">
-                  <Avatar name={org.name} src={org.image} w="45px" h="45px" />
+                  <Avatar
+                    name={org.name}
+                    src={org.image}
+                    w="45px"
+                    h="45px"
+                    // Neutral backing for logos with transparency, so Chakra's
+                    // name-derived colour doesn't show through the image.
+                    bg={org.image ? "white" : undefined}
+                  />
                   <Text ml="4" textAlign="left">
                     {" "}
                     {org.name}

--- a/src/pages/Organisations.tsx
+++ b/src/pages/Organisations.tsx
@@ -117,6 +117,8 @@ const OrgList = () => {
                     // Neutral backing for logos with transparency, so Chakra's
                     // name-derived colour doesn't show through the image.
                     bg={org.image ? "white" : undefined}
+                    borderWidth="2px"
+                    borderColor="blue.400"
                   />
                   <Text ml="4" textAlign="left">
                     {" "}

--- a/src/pages/SubCategory.tsx
+++ b/src/pages/SubCategory.tsx
@@ -20,7 +20,7 @@ import {
 import { orgRequest } from "services";
 import { convertParamsToString } from "helpers/stringManipulations";
 import { useState } from "react";
-import { CategoryType } from "./CreateAttendance";
+import { CategoryType } from "hooks/useCategories";
 import { toast } from "react-toastify";
 import Loader from "components/Loader";
 import BackButton from "components/BackButton";

--- a/src/zStore.ts
+++ b/src/zStore.ts
@@ -4,8 +4,10 @@ import { PermissionKey } from "rbac/permissions";
 
 export type currentAttendanceType = {
   name: string;
-  categoryId?: string;
-  subCategoryId?: string;
+  // null explicitly clears the field on PUT /attendance/:id; undefined would be
+  // dropped from the request body and read as "leave unchanged" by the backend.
+  categoryId?: string | null;
+  subCategoryId?: string | null;
   date: string;
   members?: Array<any>;
 };

--- a/src/zStore.ts
+++ b/src/zStore.ts
@@ -6,7 +6,7 @@ export type currentAttendanceType = {
   name: string;
   categoryId?: string;
   subCategoryId?: string;
-  date: Date;
+  date: string;
   members?: Array<any>;
 };
 
@@ -74,7 +74,7 @@ const globalStore = <F extends Function>(set: F) => ({
     name: "",
     categoryId: "",
     subCategoryId: "",
-    date: new Date(),
+    date: "",
     members: [],
   },
   updateCurrentAttendance: (currentAttendance: currentAttendanceType) => {


### PR DESCRIPTION
Promotes the editable-attendance-details + org-logo work from `dev` to `main`. (16 commits; `main` was otherwise current with `dev`.)

## What & why

1. **Editable session details on attendance edit.** The edit screen previously only let you re-toggle member present/apology. You can now edit the session **name, category, sub-category, and date** too. The fields live in a shared, fully-controlled `AttendanceDetailsForm` reused by the create screen, and on the (mobile-first) edit screen they open in a **slide-over drawer** via a compact pencil icon beside Refresh — so the member roster keeps the screen.
2. **Org logo now renders.** A saved logo URL round-tripped to the backend but nothing displayed it; the org-list avatar (and a live settings preview) now show it, with a neutral white backing + thin border so transparent logos don't reveal Chakra's name-color.

## Structure / DRY

- `useCategories(orgId)` hook centralizes the category fetch both screens needed (derives from the query cache, not `onSuccess`→state).
- `AttendanceDetailsForm` is presentational/controlled — one source of truth for the fields; `CreateAttendance` refactored onto it (behavior-preserving).
- `currentAttendanceType.date` corrected `Date`→`string` (matches how it's used everywhere); category fields widened to `string | null`.

## Notable correctness fixes (from the final review)

- **Refocus no longer wipes edits:** the edit GET uses `refetchOnWindowFocus: false`, so alt-tabbing mid-edit can't revert your typed name/category/date/member changes.
- **Clearing a category persists:** the edit write-back sends `null` (not `undefined`, which axios drops) so a cleared category actually clears server-side. *(BE must treat `null` as clear — confirmed as the intended contract.)*
- Date input capped at the user's **local** day (not the UTC day).

## Verification

- `npx tsc --noEmit` clean
- `CI=true yarn test` → 25 suites / 67 tests pass (incl. new `useCategories` + `AttendanceDetailsForm` tests)
- `CI=true yarn build` clean

## How it was built

Brainstorm → spec → plan → 5 tasks executed by fresh subagents, each independently reviewed, then a whole-branch review whose two findings (refocus-clobber, category-clear) were fixed. Specs/plans under `docs/superpowers/`.

## Follow-ups (non-blocking)

- `useCategories` `data?.data` is `any`-typed (pre-existing codebase pattern).
- `MarkAttendance` `details`/`onDetailsChange` recomputed per render (no `useCallback`); no functional impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)